### PR TITLE
Feature: use specific version of netclient

### DIFF
--- a/cmd/use.go
+++ b/cmd/use.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/gravitl/netclient/functions"
+	"github.com/spf13/cobra"
+)
+
+// useCmd represents the use command
+var useCmd = &cobra.Command{
+	Use:   "use [version]",
+	Args:  cobra.ExactArgs(1),
+	Short: "use a specific version of netclient",
+	Long: `use a specific version of netclient if available
+For example:- netclient use v0.18.0`,
+	Run: func(cmd *cobra.Command, args []string) {
+		functions.UseVersion(args[0])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(useCmd)
+}

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -7,7 +7,7 @@ import (
 
 // useCmd represents the use command
 var useCmd = &cobra.Command{
-	Use:   "use [version]",
+	Use:   "use version",
 	Args:  cobra.ExactArgs(1),
 	Short: "use a specific version of netclient",
 	Long: `use a specific version of netclient if available

--- a/functions/use_version.go
+++ b/functions/use_version.go
@@ -25,7 +25,7 @@ func createDirIfNotExists() {
 }
 
 func downloadVersion(version string) {
-	res, err := http.Get(fmt.Sprintf("https://github.com/gravitl/netmaker/releases/download/%s/netclient-%s-%s", version, runtime.GOOS, runtime.GOARCH))
+	res, err := http.Get(fmt.Sprintf("https://github.com/gravitl/netclient/releases/download/%s/netclient-%s-%s", version, runtime.GOOS, runtime.GOARCH))
 	if err != nil {
 		log.Fatal("Error making HTTP request: ", err)
 	}

--- a/functions/use_version.go
+++ b/functions/use_version.go
@@ -1,0 +1,82 @@
+package functions
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var binPath, filePath string
+
+func createDirIfNotExists() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	binPath = filepath.Join(homeDir, ".netmaker", "bin")
+	if err := os.MkdirAll(binPath, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func downloadVersion(version string) {
+	res, err := http.Get(fmt.Sprintf("https://github.com/gravitl/netmaker/releases/download/%s/netclient-%s-%s", version, runtime.GOOS, runtime.GOARCH))
+	if err != nil {
+		log.Fatal("Error making HTTP request: ", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		log.Fatal("Error making HTTP request Code: ", res.StatusCode)
+	}
+	file, err := os.Create(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := io.Copy(file, res.Body); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.Chmod(filePath, 0755); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// UseVersion switches the current netclient version to the one specified if available in the github releases page
+func UseVersion(version string) {
+	createDirIfNotExists()
+	filePath = filepath.Join(binPath, "netclient-"+version)
+	if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
+		downloadVersion(version)
+	}
+	dst, err := os.Executable()
+	if err != nil {
+		log.Fatal(err)
+	}
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpPath := dst + "-tmp"
+	tmpFile, err := os.Create(tmpPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := tmpFile.Write(src); err != nil {
+		log.Fatal(err)
+	}
+	tmpFile.Close()
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.Remove(dst); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/functions/use_version.go
+++ b/functions/use_version.go
@@ -25,7 +25,11 @@ func createDirIfNotExists() {
 }
 
 func downloadVersion(version string) {
-	res, err := http.Get(fmt.Sprintf("https://github.com/gravitl/netclient/releases/download/%s/netclient-%s-%s", version, runtime.GOOS, runtime.GOARCH))
+	url := fmt.Sprintf("https://github.com/gravitl/netclient/releases/download/%s/netclient-%s-%s", version, runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		url += ".exe"
+	}
+	res, err := http.Get(url)
 	if err != nil {
 		log.Fatal("Error making HTTP request: ", err)
 	}
@@ -66,10 +70,10 @@ func UseVersion(version string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer tmpFile.Close()
 	if _, err := tmpFile.Write(src); err != nil {
 		log.Fatal(err)
 	}
-	tmpFile.Close()
 	if err := os.Chmod(tmpPath, 0755); err != nil {
 		log.Fatal(err)
 	}

--- a/functions/use_version.go
+++ b/functions/use_version.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/gravitl/netclient/daemon"
 )
 
 var binPath, filePath string
@@ -60,6 +62,7 @@ func UseVersion(version string) {
 	if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
 		downloadVersion(version)
 	}
+	daemon.Stop()
 	dst, err := os.Executable()
 	if err != nil {
 		log.Fatal(err)
@@ -86,4 +89,5 @@ func UseVersion(version string) {
 	if err := os.Rename(tmpPath, dst); err != nil {
 		log.Fatal(err)
 	}
+	daemon.Start()
 }

--- a/functions/use_version.go
+++ b/functions/use_version.go
@@ -35,6 +35,9 @@ func downloadVersion(version string) {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusNotFound {
+			log.Fatal("Specified version of netclient doesn't exist")
+		}
 		log.Fatal("Error making HTTP request Code: ", res.StatusCode)
 	}
 	file, err := os.Create(filePath)


### PR DESCRIPTION
All released binaries must adhere to the following name format `netclient-{platform}-{architecture}` 