### PR TITLE
darwin apply addrs fix

### DIFF
--- a/wireguard/types.go
+++ b/wireguard/types.go
@@ -28,15 +28,18 @@ func NewNCIface(host *config.Config, nodes config.NodeMap) *NCIface {
 	peers := []wgtypes.PeerConfig{}
 	addrs := []ifaceAddress{}
 	for _, node := range nodes {
-		addrs = append(addrs,
-			ifaceAddress{
+		if node.Address.IP != nil {
+			addrs = append(addrs, ifaceAddress{
 				IP:      node.Address.IP,
 				Network: node.NetworkRange,
-			},
-			ifaceAddress{
+			})
+		}
+		if node.Address6.IP != nil {
+			addrs = append(addrs, ifaceAddress{
 				IP:      node.Address6.IP,
 				Network: node.NetworkRange6,
 			})
+		}
 		if config.Netclient().ProxyEnabled {
 			node.Peers = peer.SetPeersEndpointToProxy(node.Network, node.Peers)
 		}

--- a/wireguard/wireguard_darwin.go
+++ b/wireguard/wireguard_darwin.go
@@ -24,25 +24,24 @@ func (nc *NCIface) ApplyAddrs() error {
 					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), out))
 					continue
 				}
-			}
-			if address.IP.To16() != nil {
+			} else {
 				cmd := exec.Command("ifconfig", nc.Name, "inet6", address.IP.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
 					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), out))
 					continue
 				}
 			}
+
 		}
 		if address.Network.IP != nil {
-			if address.Network.IP.To16() != nil {
-				cmd := exec.Command("route", "add", "-inet6", address.Network.String(), "-interface", nc.Name)
+			if address.Network.IP.To4() != nil {
+				cmd := exec.Command("route", "add", "-net", address.Network.String(), "-interface", nc.Name)
 				if out, err := cmd.CombinedOutput(); err != nil {
 					logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), out))
 					continue
 				}
-			}
-			if address.Network.IP.To4() != nil {
-				cmd := exec.Command("route", "add", "-net", address.Network.String(), "-interface", nc.Name)
+			} else {
+				cmd := exec.Command("route", "add", "-inet6", address.Network.String(), "-interface", nc.Name)
 				if out, err := cmd.CombinedOutput(); err != nil {
 					logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), out))
 					continue


### PR DESCRIPTION
-> `IP.To16()` is not a valid check for ipv4 addrs instead only check if ipv4 by `IP.To4()` else apply as ipv6