### PR TITLE
refactored how daemon treats node delete message

### DIFF
--- a/cmd/leave.go
+++ b/cmd/leave.go
@@ -22,7 +22,7 @@ For example:
 netclient leave my-network`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.Log(0, "leave called")
-		faults, err := functions.LeaveNetwork(args[0])
+		faults, err := functions.LeaveNetwork(args[0], false)
 		if err != nil {
 			fmt.Println(err.Error())
 			for _, fault := range faults {

--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -332,15 +332,8 @@ func unsubscribeNode(client mqtt.Client, node *config.Node) {
 			logger.Log(1, "network:", node.Network, "unable to unsubscribe from updates for node ", node.ID.String(), "\n", token.Error().Error())
 		}
 		ok = false
-	}
-	if token := client.Unsubscribe(fmt.Sprintf("peers/%s/%s", node.Network, node.ID)); token.WaitTimeout(mq.MQ_TIMEOUT*time.Second) && token.Error() != nil {
-		if token.Error() == nil {
-			logger.Log(1, "network:", node.Network, "unable to unsubscribe from peer updates for node", node.ID.String(), "\n", "connection timeout")
-		} else {
-			logger.Log(1, "network:", node.Network, "unable to unsubscribe from peer updates for node", node.ID.String(), "\n", token.Error().Error())
-		}
-		ok = false
-	}
+	} // peer updates belong to host now
+
 	if ok {
 		logger.Log(1, "network:", node.Network, "successfully unsubscribed node ", node.ID.String())
 	}

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -58,7 +58,7 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 	case models.NODE_DELETE:
 		logger.Log(0, "network:", newNode.Network, " received delete request for %s", newNode.ID.String())
 		unsubscribeNode(client, &newNode)
-		if _, err = LeaveNetwork(newNode.Network); err != nil {
+		if _, err = LeaveNetwork(newNode.Network, true); err != nil {
 			if !strings.Contains("rpc error", err.Error()) {
 				logger.Log(0, "failed to leave, please check that local files for network", newNode.Network, "were removed")
 				return

--- a/functions/uninstall.go
+++ b/functions/uninstall.go
@@ -57,6 +57,10 @@ func LeaveNetwork(network string, isDaemon bool) ([]error, error) {
 				faults = append(faults, fmt.Errorf("issue setting peers after node removal - %v", err.Error()))
 			}
 		}
+	} else { // was called from CLI so restart daemon
+		if err := daemon.Restart(); err != nil {
+			faults = append(faults, fmt.Errorf("could not restart daemon after leave - %v", err.Error()))
+		}
 	}
 
 	if len(faults) > 0 {

--- a/functions/uninstall.go
+++ b/functions/uninstall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devilcove/httpclient"
 	"github.com/gravitl/netclient/config"
 	"github.com/gravitl/netclient/daemon"
+	"github.com/gravitl/netclient/wireguard"
 	"github.com/gravitl/netmaker/logger"
 )
 
@@ -18,7 +19,7 @@ func Uninstall() ([]error, error) {
 	allfaults := []error{}
 	var err error
 	for network := range config.Nodes {
-		faults, err := LeaveNetwork(network)
+		faults, err := LeaveNetwork(network, false)
 		if err != nil {
 			allfaults = append(allfaults, faults...)
 		}
@@ -30,30 +31,34 @@ func Uninstall() ([]error, error) {
 }
 
 // LeaveNetwork - client exits a network
-func LeaveNetwork(network string) ([]error, error) {
+func LeaveNetwork(network string, isDaemon bool) ([]error, error) {
 	faults := []error{}
-	fmt.Println("\nleaving network", network)
 	node, ok := config.Nodes[network]
 	if !ok {
-		fmt.Printf("\nnot connected to network: %s", network)
 		return faults, fmt.Errorf("not connected to network: %s", network)
 	}
-	fmt.Println("deleting node from server")
 	if err := deleteNodeFromServer(&node); err != nil {
 		faults = append(faults, fmt.Errorf("error deleting nodes from server %w", err))
 	}
-	fmt.Println("deleting wireguard interface")
+	// remove node from config
 	if err := deleteLocalNetwork(&node); err != nil {
 		faults = append(faults, fmt.Errorf("error deleting wireguard interface %w", err))
 	}
-	fmt.Println("removing dns entries")
 	if err := removeHostDNS(node.Network); err != nil {
 		faults = append(faults, fmt.Errorf("failed to delete dns entries %w", err))
 	}
-	fmt.Println("restarting daemon")
-	if err := daemon.Restart(); err != nil {
-		faults = append(faults, fmt.Errorf("error restarting daemon %w", err))
+	// re-configure interface if daemon is calling leave
+	if isDaemon {
+		nc := wireguard.NewNCIface(config.Netclient(), config.GetNodes())
+		if err := nc.Configure(); err != nil {
+			faults = append(faults, fmt.Errorf("failed to configure interface during node removal - %v", err.Error()))
+		} else {
+			if err = wireguard.SetPeers(); err != nil {
+				faults = append(faults, fmt.Errorf("issue setting peers after node removal - %v", err.Error()))
+			}
+		}
 	}
+
 	if len(faults) > 0 {
 		return faults, errors.New("error(s) leaving nework")
 	}


### PR DESCRIPTION
To test: 
- Add a node to a server
- Delete said node from server
- node should be removed locally from netclient configs and from server DB
Relevant netclient logs: `<node ID>, "was removed from network", <network ID>`