### PR TITLE
Gra 1060/publish listen port bug

### DIFF
--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -243,7 +243,7 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 		config.WriteServerConfig()
 		resetInterface = true
 	case models.UpdateHost:
-		resetInterface, sendHostUpdate, restartDaemon = updateHostConfig(&hostUpdate.Host)
+		resetInterface, restartDaemon = updateHostConfig(&hostUpdate.Host)
 	default:
 		logger.Log(1, "unknown host action")
 		return
@@ -289,7 +289,7 @@ func deleteHostCfg(client mqtt.Client, server string) {
 	delete(ServerSet, server)
 }
 
-func updateHostConfig(host *models.Host) (resetInterface, sendHostUpdate, restart bool) {
+func updateHostConfig(host *models.Host) (resetInterface, restart bool) {
 	hostCfg := config.Netclient()
 	if hostCfg == nil || host == nil {
 		return
@@ -300,12 +300,8 @@ func updateHostConfig(host *models.Host) (resetInterface, sendHostUpdate, restar
 	if hostCfg.MTU != host.MTU {
 		resetInterface = true
 	}
-	if hostCfg.PublicListenPort != 0 && hostCfg.PublicListenPort != host.PublicListenPort {
-		sendHostUpdate = true
-	}
 	// store password before updating
 	host.HostPass = hostCfg.HostPass
-	host.PublicListenPort = hostCfg.PublicListenPort
 	hostCfg.Host = *host
 	config.UpdateNetclient(*hostCfg)
 	config.WriteNetclientConfig()

--- a/functions/mqpublish.go
+++ b/functions/mqpublish.go
@@ -381,15 +381,16 @@ func UpdateHostSettings() error {
 		publishMsg = true
 	}
 	if config.Netclient().ProxyEnabled {
-		publishMsg = true
+
 		if config.Netclient().ProxyListenPort != proxylistenPort {
 			logger.Log(1, fmt.Sprint("proxy listen port has changed from ", config.Netclient().ProxyListenPort, " to ", proxylistenPort))
 			config.Netclient().ProxyListenPort = proxylistenPort
-
+			publishMsg = true
 		}
 		if config.Netclient().PublicListenPort != proxypublicport {
 			logger.Log(1, fmt.Sprint("public listen port has changed from ", config.Netclient().PublicListenPort, " to ", proxypublicport))
 			config.Netclient().PublicListenPort = proxypublicport
+			publishMsg = true
 		}
 	}
 	if proxyCfg.GetCfg().IsBehindNAT() && !config.Netclient().ProxyEnabled {

--- a/functions/mqpublish.go
+++ b/functions/mqpublish.go
@@ -381,16 +381,15 @@ func UpdateHostSettings() error {
 		publishMsg = true
 	}
 	if config.Netclient().ProxyEnabled {
+		publishMsg = true
 		if config.Netclient().ProxyListenPort != proxylistenPort {
 			logger.Log(1, fmt.Sprint("proxy listen port has changed from ", config.Netclient().ProxyListenPort, " to ", proxylistenPort))
 			config.Netclient().ProxyListenPort = proxylistenPort
-			publishMsg = true
 
 		}
 		if config.Netclient().PublicListenPort != proxypublicport {
 			logger.Log(1, fmt.Sprint("public listen port has changed from ", config.Netclient().PublicListenPort, " to ", proxypublicport))
 			config.Netclient().PublicListenPort = proxypublicport
-			publishMsg = true
 		}
 	}
 	if proxyCfg.GetCfg().IsBehindNAT() && !config.Netclient().ProxyEnabled {

--- a/nmproxy/nm-proxy.go
+++ b/nmproxy/nm-proxy.go
@@ -35,9 +35,6 @@ func Start(ctx context.Context, wg *sync.WaitGroup, mgmChan chan *nm_models.Host
 	config.GetCfg().SetHostInfo(stun.GetHostInfo(stunAddr, stunPort, proxyPort))
 	logger.Log(0, fmt.Sprintf("HOSTINFO: %+v", config.GetCfg().GetHostInfo()))
 	config.GetCfg().SetNATStatus()
-	// nc_config.Netclient().ProxyListenPort = proxyPort
-	// nc_config.Netclient().PublicListenPort = config.GetCfg().GetHostInfo().PubPort
-	// nc_config.WriteNetclientConfig()
 	// start the netclient proxy server
 	err := server.NmProxyServer.CreateProxyServer(proxyPort, 0, config.GetCfg().GetHostInfo().PrivIp.String())
 	if err != nil {

--- a/nmproxy/nm-proxy.go
+++ b/nmproxy/nm-proxy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	nc_config "github.com/gravitl/netclient/config"
 	"github.com/gravitl/netclient/nmproxy/config"
 	"github.com/gravitl/netclient/nmproxy/manager"
 	"github.com/gravitl/netclient/nmproxy/models"
@@ -36,9 +35,9 @@ func Start(ctx context.Context, wg *sync.WaitGroup, mgmChan chan *nm_models.Host
 	config.GetCfg().SetHostInfo(stun.GetHostInfo(stunAddr, stunPort, proxyPort))
 	logger.Log(0, fmt.Sprintf("HOSTINFO: %+v", config.GetCfg().GetHostInfo()))
 	config.GetCfg().SetNATStatus()
-	nc_config.Netclient().ProxyListenPort = proxyPort
-	nc_config.Netclient().PublicListenPort = config.GetCfg().GetHostInfo().PubPort
-	nc_config.WriteNetclientConfig()
+	// nc_config.Netclient().ProxyListenPort = proxyPort
+	// nc_config.Netclient().PublicListenPort = config.GetCfg().GetHostInfo().PubPort
+	// nc_config.WriteNetclientConfig()
 	// start the netclient proxy server
 	err := server.NmProxyServer.CreateProxyServer(proxyPort, 0, config.GetCfg().GetHostInfo().PrivIp.String())
 	if err != nil {


### PR DESCRIPTION
-> only update public listen port during checkin
**Server version : https://github.com/gravitl/netmaker/pull/1978**
testing steps:

- [x]  for host behind NAT, and check on it's peer's wg interface if port is pointing to public port of host behind NAT
- [x] you can verify the public_listen_port value in the netclient.yml file `public_listen_port`
- [x] also verify `public_listen_port` in the API response of host, maybe you check in the developer tools in the browser for API response