### PR TITLE
put nil check on peers

### DIFF
--- a/functions/list.go
+++ b/functions/list.go
@@ -37,6 +37,10 @@ func List(net string, long bool) {
 					logger.Log(1, "failed to get peers for node: ", node.ID.String(), " Err: ", err.Error())
 					continue
 				}
+				if len(peers) == 0 {
+					logger.Log(1, "no peers present on network", node.Network)
+					continue
+				}
 				entry["peers"] = make([]map[string]any, 0)
 				for _, peer := range peers {
 					p := map[string]any{


### PR DESCRIPTION
to test:

- [x] ensure list on GUI network details doesn't cause a nil pointer
- [x] ensure calling `list -l` (when no peers or unable to reach server) doesn't cause nil pointer