### PR TITLE
Gra 1054/route manager

### DIFF
--- a/nmproxy/router/iptables_linux.go
+++ b/nmproxy/router/iptables_linux.go
@@ -185,7 +185,10 @@ func (i *iptablesManager) removeJumpRules() {
 	if err == nil {
 		for _, rule := range rules {
 			if addedByNetmaker(rule) {
-				i.ipv4Client.Delete(defaultIpTable, iptableFWDChain)
+				err := i.ipv4Client.Delete(defaultIpTable, iptableFWDChain, strings.Fields(rule)[2:]...)
+				if err != nil {
+					logger.Log(0, "failed to delete rule: ", rule, err.Error())
+				}
 			}
 		}
 	}
@@ -193,7 +196,10 @@ func (i *iptablesManager) removeJumpRules() {
 	if err == nil {
 		for _, rule := range rules {
 			if addedByNetmaker(rule) {
-				i.ipv6Client.Delete(defaultIpTable, iptableFWDChain)
+				err := i.ipv6Client.Delete(defaultIpTable, iptableFWDChain, strings.Fields(rule)[2:]...)
+				if err != nil {
+					logger.Log(0, "failed to delete rule: ", rule, err.Error())
+				}
 			}
 		}
 	}
@@ -201,7 +207,10 @@ func (i *iptablesManager) removeJumpRules() {
 	if err == nil {
 		for _, rule := range rules {
 			if addedByNetmaker(rule) {
-				i.ipv4Client.Delete(defaultNatTable, nattablePRTChain)
+				err := i.ipv4Client.Delete(defaultNatTable, nattablePRTChain, strings.Fields(rule)[2:]...)
+				if err != nil {
+					logger.Log(0, "failed to delete rule: ", rule, err.Error())
+				}
 			}
 		}
 	}
@@ -209,7 +218,10 @@ func (i *iptablesManager) removeJumpRules() {
 	if err == nil {
 		for _, rule := range rules {
 			if addedByNetmaker(rule) {
-				i.ipv6Client.Delete(defaultNatTable, nattablePRTChain)
+				err := i.ipv6Client.Delete(defaultNatTable, nattablePRTChain, strings.Fields(rule)[2:]...)
+				if err != nil {
+					logger.Log(0, "failed to delete rule: ", rule, err.Error())
+				}
 			}
 		}
 	}

--- a/nmproxy/router/iptables_linux.go
+++ b/nmproxy/router/iptables_linux.go
@@ -27,11 +27,10 @@ const (
 )
 
 type iptablesManager struct {
-	ipv4Client   *iptables.IPTables
-	ipv6Client   *iptables.IPTables
-	ingRules     serverrulestable
-	defaultRules ruletable
-	mux          sync.Mutex
+	ipv4Client *iptables.IPTables
+	ipv6Client *iptables.IPTables
+	ingRules   serverrulestable
+	mux        sync.Mutex
 }
 
 var (


### PR DESCRIPTION
-> added netmaker tags to jump rules, better way to handle the cleanup of rules

testing steps:

- [x] add an ext. client to ingress node check if rules with `NETMAKER` is attached  ( `iptables -L`)
- [x]  verify if ext clients are able communicate with peers
- [x] shutdown daemon, and check all rules are cleanedup that are added by netmaker