### PR TITLE
added host nil check during peers get

### DIFF
--- a/functions/list.go
+++ b/functions/list.go
@@ -68,7 +68,11 @@ func List(net string, long bool) {
 func GetNodePeers(node config.Node) ([]wgtypes.PeerConfig, error) {
 
 	server := config.GetServer(node.Server)
-	token, err := Authenticate(server.API, config.Netclient())
+	host := config.Netclient()
+	if host == nil {
+		return nil, fmt.Errorf("no configured host found")
+	}
+	token, err := Authenticate(server.API, host)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To test:
- [x] after a gui join a nil pointer would be thrown (for first join for a netclient), ensure during GUI join one is not.