### PR TITLE
GRA-1154: skip peer update if no nodes exist

### DIFF
--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -128,6 +128,10 @@ func NodeUpdate(client mqtt.Client, msg mqtt.Message) {
 func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 	var peerUpdate models.HostPeerUpdate
 	var err error
+	if len(config.GetNodes()) == 0 {
+		logger.Log(3, "skipping unwanted peer update, no nodes exist")
+		return
+	}
 	serverName := parseServerFromTopic(msg.Topic())
 	server := config.GetServer(serverName)
 	if server == nil {
@@ -157,6 +161,7 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 		logger.Log(0, "error updating wireguard peers"+err.Error())
 		return
 	}
+
 	config.UpdateHostPeers(serverName, peerUpdate.Peers)
 	config.WriteNetclientConfig()
 	nc := wireguard.NewNCIface(config.Netclient(), config.GetNodes())


### PR DESCRIPTION
- this will fix clearing out the interface on leaving the last network
Testing Steps:

- [x] check whether on leaving the last network peer are removed from the interface
- [x] Also verify whether peer data is deleted from config files