### PR TITLE
GRA-1156: reset ext.client proxy connection on endpoint change

### DIFF
--- a/nmproxy/manager/manager.go
+++ b/nmproxy/manager/manager.go
@@ -222,7 +222,7 @@ func (m *proxyPayload) processPayload() error {
 			if peerConn.IsExtClient {
 				logger.Log(1, "------> Deleting ExtClient Watch Thread: ", peerConn.Key.String())
 				gCfg.DeleteExtWaitCfg(peerConn.Key.String())
-				gCfg.DeleteExtClientInfo(peerConn.Config.PeerConf.Endpoint)
+				gCfg.DeleteExtClientInfo(peerConn.Config.PeerEndpoint)
 			}
 			gCfg.DeletePeerHash(peerConn.Key.String())
 			gCfg.RemovePeer(peerConn.Key.String())
@@ -439,7 +439,7 @@ func (m *proxyPayload) peerUpdate() error {
 				config.GetCfg().SaveExtclientWaitCfg(&extPeer)
 				defer func() {
 					if addExtClient {
-						logger.Log(1, "Got endpoint for Extclient adding peer...", extPeer.Endpoint.String())
+						logger.Log(1, "Got endpoint for Extclient adding peer...", peer.Endpoint.String())
 						peerpkg.AddNew(server, peer, peerConf, isRelayed, relayedTo)
 					}
 					logger.Log(1, "Exiting extclient watch Thread for: ", peer.PublicKey.String())

--- a/nmproxy/proxy/proxy_helper.go
+++ b/nmproxy/proxy/proxy_helper.go
@@ -89,7 +89,10 @@ func (p *Proxy) Reset() {
 	logger.Log(0, "Resetting proxy connection for peer: ", p.Config.PeerPublicKey.String())
 	p.Close()
 	time.Sleep(time.Second * 3)
-	endpoint := p.Config.PeerEndpoint
+	if p.Config.PeerEndpoint == nil {
+		return
+	}
+	endpoint := *p.Config.PeerEndpoint
 	if err := p.pullLatestConfig(); err != nil {
 		logger.Log(1, "couldn't perform reset: ", p.Config.PeerPublicKey.String(), err.Error())
 	}
@@ -107,7 +110,7 @@ func (p *Proxy) Reset() {
 		peer.LocalConn = p.LocalConn
 		config.GetCfg().SavePeerByHash(&peer)
 	}
-	if extpeer, found := config.GetCfg().GetExtClientInfo(endpoint); found {
+	if extpeer, found := config.GetCfg().GetExtClientInfo(&endpoint); found {
 		extpeer.LocalConn = p.LocalConn
 		extpeer.Endpoint = p.Config.PeerEndpoint
 		config.GetCfg().SaveExtClientInfo(&extpeer)

--- a/nmproxy/proxy/proxy_helper.go
+++ b/nmproxy/proxy/proxy_helper.go
@@ -97,7 +97,12 @@ func (p *Proxy) Reset() {
 		logger.Log(1, "couldn't perform reset: ", p.Config.PeerPublicKey.String(), err.Error())
 	}
 	p = New(p.Config)
-	p.Start()
+	err := p.Start()
+	if err != nil {
+		logger.Log(0, "Failed to reset proxy for peer: ",
+			p.Config.PeerPublicKey.String(), "Err: ", err.Error())
+		return
+	}
 	// update peer configs
 	if peer, found := config.GetCfg().GetPeer(p.Config.PeerPublicKey.String()); found {
 		peer.Config = p.Config

--- a/nmproxy/proxy/proxy_helper.go
+++ b/nmproxy/proxy/proxy_helper.go
@@ -88,9 +88,12 @@ func (p *Proxy) toRemote(wg *sync.WaitGroup) {
 func (p *Proxy) Reset() {
 	logger.Log(0, "Resetting proxy connection for peer: ", p.Config.PeerPublicKey.String())
 	p.Close()
+	time.Sleep(time.Second * 3)
+	endpoint := p.Config.PeerEndpoint
 	if err := p.pullLatestConfig(); err != nil {
 		logger.Log(1, "couldn't perform reset: ", p.Config.PeerPublicKey.String(), err.Error())
 	}
+	p = New(p.Config)
 	p.Start()
 	// update peer configs
 	if peer, found := config.GetCfg().GetPeer(p.Config.PeerPublicKey.String()); found {
@@ -104,8 +107,9 @@ func (p *Proxy) Reset() {
 		peer.LocalConn = p.LocalConn
 		config.GetCfg().SavePeerByHash(&peer)
 	}
-	if extpeer, found := config.GetCfg().GetExtClientInfo(p.Config.PeerEndpoint); found {
+	if extpeer, found := config.GetCfg().GetExtClientInfo(endpoint); found {
 		extpeer.LocalConn = p.LocalConn
+		extpeer.Endpoint = p.Config.PeerEndpoint
 		config.GetCfg().SaveExtClientInfo(&extpeer)
 	}
 

--- a/nmproxy/proxy/proxy_helper.go
+++ b/nmproxy/proxy/proxy_helper.go
@@ -88,7 +88,6 @@ func (p *Proxy) toRemote(wg *sync.WaitGroup) {
 func (p *Proxy) Reset() {
 	logger.Log(0, "Resetting proxy connection for peer: ", p.Config.PeerPublicKey.String())
 	p.Close()
-	time.Sleep(time.Second * 3)
 	if p.Config.PeerEndpoint == nil {
 		return
 	}

--- a/nmproxy/server/server.go
+++ b/nmproxy/server/server.go
@@ -227,9 +227,16 @@ func (p *ProxyServer) handleMsgs(buffer []byte, n int, source *net.UDPAddr) {
 						if extPeer, found := config.GetCfg().GetExtClientInfo(peerInfoHash.Endpoint); found {
 							logger.Log(1, "----> ExtClient  endpoint has changed: ", peerKey, extPeer.Endpoint.String(), " to: ", source.String())
 							// Extclient Endpoint has changed so reset connection
-							config.GetCfg().DeleteExtClientInfo(extPeer.Endpoint)
-							config.GetCfg().DeletePeerHash(peerKey)
-							config.GetCfg().RemovePeer(peerKey)
+							// config.GetCfg().DeleteExtClientInfo(extPeer.Endpoint)
+							// config.GetCfg().DeletePeerHash(peerKey)
+							// config.GetCfg().RemovePeer(peerKey)
+							if peerConn, ok := config.GetCfg().GetPeer(peerKey); ok {
+								peerConn.Config.PeerEndpoint = source
+								peerConn.Config.PeerConf.Endpoint = source
+								config.GetCfg().UpdatePeer(&peerConn)
+								config.GetCfg().ResetPeer(peerKey)
+
+							}
 
 						}
 

--- a/nmproxy/server/server.go
+++ b/nmproxy/server/server.go
@@ -227,9 +227,6 @@ func (p *ProxyServer) handleMsgs(buffer []byte, n int, source *net.UDPAddr) {
 						if extPeer, found := config.GetCfg().GetExtClientInfo(peerInfoHash.Endpoint); found {
 							logger.Log(1, "----> ExtClient  endpoint has changed: ", peerKey, extPeer.Endpoint.String(), " to: ", source.String())
 							// Extclient Endpoint has changed so reset connection
-							// config.GetCfg().DeleteExtClientInfo(extPeer.Endpoint)
-							// config.GetCfg().DeletePeerHash(peerKey)
-							// config.GetCfg().RemovePeer(peerKey)
 							if peerConn, ok := config.GetCfg().GetPeer(peerKey); ok {
 								peerConn.Config.PeerEndpoint = source
 								peerConn.Config.PeerConf.Endpoint = source


### PR DESCRIPTION
server version: https://github.com/gravitl/netmaker/pull/2023

Testing:

- [x] turn on proxy on ingress gw node, check whether ext clients are able to connect to peers
- [x] do wg-quick down, up for the ext client, which essentially listens on a new port, verify if connectivity is still intact 