### PR TITLE
GRA-1187: enable proxy automatically  for machines behind NAT only once during lifetime of daemon

### DIFF
--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -241,6 +241,7 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 		config.WriteServerConfig()
 		restartDaemon = true
 	case models.DeleteHost:
+		clearRetainedMsg(client, msg.Topic())
 		unsubscribeHost(client, serverName)
 		deleteHostCfg(client, serverName)
 		config.WriteNodeConfig()
@@ -276,7 +277,6 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 		}
 		wireguard.SetPeers()
 	}
-	clearRetainedMsg(client, msg.Topic())
 
 }
 

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -3,7 +3,6 @@ package functions
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -168,7 +167,6 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 	nc := wireguard.NewNCIface(config.Netclient(), config.GetNodes())
 	nc.Configure()
 	wireguard.SetPeers()
-	log.Println("-----------> $$$$$: PROXY STATRUS: ", config.Netclient().ProxyEnabled)
 	if config.Netclient().ProxyEnabled {
 		time.Sleep(time.Second * 2) // sleep required to avoid race condition
 		peerUpdate.ProxyUpdate.Action = models.ProxyUpdate
@@ -202,7 +200,6 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 			}
 		}
 	}
-	_ = UpdateHostSettings()
 
 }
 
@@ -309,7 +306,6 @@ func updateHostConfig(host *models.Host) (resetInterface, restart bool) {
 	if hostCfg.MTU != host.MTU {
 		resetInterface = true
 	}
-	log.Printf("-----> HOST UPDATE: %v, %v\n", host.ProxyEnabled, hostCfg.ProxyEnabled)
 	// store password before updating
 	host.HostPass = hostCfg.HostPass
 	hostCfg.Host = *host

--- a/functions/mqpublish.go
+++ b/functions/mqpublish.go
@@ -381,8 +381,10 @@ func UpdateHostSettings() error {
 			publishMsg = true
 		}
 	}
-	if proxyCfg.GetCfg().IsBehindNAT() && !config.Netclient().ProxyEnabled {
+	if proxyCfg.GetCfg().IsBehindNAT() && !config.Netclient().ProxyEnabled &&
+		!proxyCfg.NatAutoSwitchDone() {
 		logger.Log(0, "Host is behind NAT, enabling proxy...")
+		proxyCfg.SetNatAutoSwitch()
 		config.Netclient().ProxyEnabled = true
 		publishMsg = true
 	}

--- a/nmproxy/config/config.go
+++ b/nmproxy/config/config.go
@@ -12,7 +12,8 @@ import (
 
 var (
 	// contains all the config related to proxy
-	config = &Config{}
+	config        = &Config{}
+	natAutoSwitch bool
 )
 
 // Config - struct for proxy config
@@ -191,6 +192,16 @@ func (c *Config) SetNATStatus() {
 		c.isBehindNAT = true
 	}
 
+}
+
+// NatAutoSwitchDone - check if nat automatically swithed on already for devices behind NAT
+func NatAutoSwitchDone() bool {
+	return natAutoSwitch
+}
+
+// SetNatAutoSwitch - set NAT auto switch to true
+func SetNatAutoSwitch() {
+	natAutoSwitch = true
 }
 
 // Config.IsBehindNAT - checks if proxy is running behind NAT


### PR DESCRIPTION
Testing:

- [x] on a machine behind NAT, the proxy should be switched on automatically the first time since the daemon startup during check-in
- [x] check when the proxy is disabled on the machine behind NAT, it shouldn't switch on again automatically  in the next check-in

**check-in happens every 1-minute on client**