### PR TITLE
deleted unused import "log"

### DIFF
--- a/functions/join.go
+++ b/functions/join.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"


### PR DESCRIPTION
"log" is unused in join.go and can't build. removed it.