### PR TITLE
Gra 1180 default host node removal

### DIFF
--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -272,7 +272,7 @@ func setHostSubscription(client mqtt.Client, server string) {
 // setSubcriptions sets MQ client subscriptions for a specific node config
 // should be called for each node belonging to a given server
 func setSubscriptions(client mqtt.Client, node *config.Node) {
-	if token := client.Subscribe(fmt.Sprintf("update/%s/%s", node.Network, node.ID), 0, mqtt.MessageHandler(NodeUpdate)); token.WaitTimeout(mq.MQ_TIMEOUT*time.Second) && token.Error() != nil {
+	if token := client.Subscribe(fmt.Sprintf("node/update/%s/%s", node.Network, node.ID), 0, mqtt.MessageHandler(NodeUpdate)); token.WaitTimeout(mq.MQ_TIMEOUT*time.Second) && token.Error() != nil {
 		if token.Error() == nil {
 			logger.Log(0, "network:", node.Network, "connection timeout")
 		} else {
@@ -333,9 +333,8 @@ func insert(network, which, cache string) {
 // on a delete usually, pass in the nodecfg to unsubscribe client broker communications
 // for the node in nodeCfg
 func unsubscribeNode(client mqtt.Client, node *config.Node) {
-	client.Unsubscribe(fmt.Sprintf("update/%s/%s", node.Network, node.ID))
 	var ok = true
-	if token := client.Unsubscribe(fmt.Sprintf("update/%s/%s", node.Network, node.ID)); token.WaitTimeout(mq.MQ_TIMEOUT*time.Second) && token.Error() != nil {
+	if token := client.Unsubscribe(fmt.Sprintf("node/update/%s/%s", node.Network, node.ID)); token.WaitTimeout(mq.MQ_TIMEOUT*time.Second) && token.Error() != nil {
 		if token.Error() == nil {
 			logger.Log(1, "network:", node.Network, "unable to unsubscribe from updates for node ", node.ID.String(), "\n", "connection timeout")
 		} else {

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -315,7 +315,7 @@ func updateHostConfig(host *models.Host) (resetInterface, restart bool) {
 }
 
 func parseNetworkFromTopic(topic string) string {
-	return strings.Split(topic, "/")[1]
+	return strings.Split(topic, "/")[2]
 }
 
 func parseServerFromTopic(topic string) string {

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -224,7 +224,7 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 		return
 	}
 	logger.Log(3, fmt.Sprintf("---> received host update [ action: %v ] for host from %s ", hostUpdate.Action, serverName))
-	var resetInterface, sendHostUpdate, restartDaemon bool
+	var resetInterface, restartDaemon bool
 	switch hostUpdate.Action {
 	case models.JoinHostToNetwork:
 		commonNode := hostUpdate.Node.CommonNode
@@ -254,12 +254,11 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 		logger.Log(1, "unknown host action")
 		return
 	}
-	config.WriteNetclientConfig()
-	if sendHostUpdate {
-		if err := PublishHostUpdate(serverName, models.UpdateHost); err != nil {
-			logger.Log(0, "failed to send host update to server ", serverName, err.Error())
-		}
+	if err = config.WriteNetclientConfig(); err != nil {
+		logger.Log(0, "failed to write host config -", err.Error())
+		return
 	}
+
 	if restartDaemon {
 		clearRetainedMsg(client, msg.Topic())
 		if err := daemon.Restart(); err != nil {

--- a/functions/pull.go
+++ b/functions/pull.go
@@ -44,7 +44,6 @@ func Pull(network string, iface bool) (*config.Node, error) {
 	if err = config.WriteNodeConfig(); err != nil {
 		return nil, err
 	}
-	config.WriteNodeConfig()
 	//update wg config
 	config.UpdateHostPeers(node.Server, nodeGet.HostPeers)
 	internetGateway, err := wireguard.UpdateWgPeers(nodeGet.HostPeers)


### PR DESCRIPTION
Cleaned up some pointless/unused function calls as well

Reference server on PR https://github.com/gravitl/netmaker/tree/GRA-1180-default-host-delete
To test:

- [x] Ensure client receives node updates correctly
- [x] Ensure client after node's are removed from server doesn't have them
- [x] Ensure client removes server from `servers.yml` after host delete