### PR TITLE
fix copy&paste error in log message

### DIFF
--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -119,7 +119,7 @@ func (nc *NCIface) ApplyAddrs() error {
 				LinkIndex: l.Attrs().Index,
 				Dst:       &addr.Network,
 			}); err != nil {
-				logger.Log(0, "error adding addr", err.Error())
+				logger.Log(0, "error adding route", err.Error())
 				return err
 			}
 		}


### PR DESCRIPTION
It seems someone copied the log message statement from a few lines earlier and forgot to adjust the message from addr to route.