### PR TITLE
GRA-1360 - fixed mqtt singleton

### DIFF
--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -235,6 +235,7 @@ func setupMQTTSingleton(server *config.Server, publishOnly bool) error {
 			}
 			setHostSubscription(client, server.Name)
 		}
+		logger.Log(1, "successfully connected to", server.Broker)
 	})
 	opts.SetOrderMatters(true)
 	opts.SetResumeSubs(true)
@@ -245,7 +246,7 @@ func setupMQTTSingleton(server *config.Server, publishOnly bool) error {
 	ServerSet[server.Name] = mqclient
 	var connecterr error
 	if token := mqclient.Connect(); !token.WaitTimeout(30*time.Second) || token.Error() != nil {
-		logger.Log(0, "unable to connect to broker, retrying ...")
+		logger.Log(0, "unable to connect to broker,", server.Broker+",", "retrying...")
 		if token.Error() == nil {
 			connecterr = errors.New("connect timeout")
 		} else {

--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -216,9 +216,7 @@ func setupMQTT(server *config.Server) error {
 // only to be called from cli (eg. connect/disconnect, join, leave) and not from daemon ---
 func setupMQTTSingleton(server *config.Server, publishOnly bool) error {
 	opts := mqtt.NewClientOptions()
-	broker := server.Broker
-	port := server.MQPort
-	opts.AddBroker(fmt.Sprintf("wss://%s:%s", broker, port))
+	opts.AddBroker(server.Broker)
 	opts.SetUsername(server.MQUserName)
 	opts.SetPassword(server.MQPassword)
 	opts.SetClientID(server.MQID.String())


### PR DESCRIPTION
Critical issue:
When mqtt singletons are created, they are referencing broker incorrectly since 0.18.2 update
fixed it.

To test:

- [x] Ensure an uninstall can reach broker (can see log with verbosity of 1)