### PR TITLE
fix typo in the readme commands section for netclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Available Commands:
 Flags:
       --config string   use specified config file
   -h, --help            help for netclient
-  -v, --verbosity int   set loggin verbosity 0-4
+  -v, --verbosity int   set logging verbosity 0-4
 
 Use "netclient [command] --help" for more information about a command.
 ```


### PR DESCRIPTION
a small typo fix in the readme for netclient