### PR TITLE
GRA-1436: nil checks for peer (ext. client) endpoint

### DIFF
--- a/functions/list.go
+++ b/functions/list.go
@@ -64,7 +64,9 @@ func List(net string, long bool) {
 				for _, peer := range peers {
 					p := peerOut{
 						PublicKey: peer.PublicKey.String(),
-						Endpoint:  peer.Endpoint.String(),
+					}
+					if peer.Endpoint != nil {
+						p.Endpoint = peer.Endpoint.String()
 					}
 
 					for _, cidr := range peer.AllowedIPs {

--- a/nmproxy/manager/manager.go
+++ b/nmproxy/manager/manager.go
@@ -228,20 +228,23 @@ func (m *proxyPayload) processPayload() error {
 				gCfg.DeletePeerHash(peerConn.Key.String())
 				gCfg.RemovePeer(peerConn.Key.String())
 			}
-			if peerConn, ok := gCfg.GetNoProxyPeer(m.Peers[i].Endpoint.IP); ok {
-				_, found := peerConn.ServerMap[m.Server]
-				if !found {
-					continue
-				} else {
-					delete(peerConn.ServerMap, m.Server)
-					noProxyPeerMap[m.Peers[i].Endpoint.IP.String()] = &peerConn
-					if len(peerConn.ServerMap) > 0 {
+			if m.Peers[i].Endpoint != nil {
+				if peerConn, ok := gCfg.GetNoProxyPeer(m.Peers[i].Endpoint.IP); ok {
+					_, found := peerConn.ServerMap[m.Server]
+					if !found {
 						continue
-					}
+					} else {
+						delete(peerConn.ServerMap, m.Server)
+						noProxyPeerMap[m.Peers[i].Endpoint.IP.String()] = &peerConn
+						if len(peerConn.ServerMap) > 0 {
+							continue
+						}
 
+					}
+					gCfg.DeleteNoProxyPeer(m.Peers[i].Endpoint.IP.String())
 				}
-				gCfg.DeleteNoProxyPeer(m.Peers[i].Endpoint.IP.String())
 			}
+
 			continue
 		}
 
@@ -272,7 +275,7 @@ func (m *proxyPayload) processPayload() error {
 			if err == nil {
 				logger.Log(3, fmt.Sprintf("---------> comparing peer endpoint: onDevice: %s, Proxy: %s", devPeer.Endpoint.String(),
 					currentPeer.Config.LocalConnAddr.String()))
-				if devPeer.Endpoint.String() != currentPeer.Config.LocalConnAddr.String() {
+				if devPeer.Endpoint != nil && devPeer.Endpoint.String() != currentPeer.Config.LocalConnAddr.String() {
 					logger.Log(1, "---------> endpoint is not set to proxy: ", currentPeer.Key.String())
 					currentPeer.StopConn()
 					currentPeer.Mutex.Unlock()
@@ -314,7 +317,7 @@ func (m *proxyPayload) processPayload() error {
 				continue
 			}
 
-			if currentPeer.Config.PeerConf.Endpoint.IP.String() != m.Peers[i].Endpoint.IP.String() {
+			if m.Peers[i].Endpoint != nil && currentPeer.Config.PeerConf.Endpoint.IP.String() != m.Peers[i].Endpoint.IP.String() {
 				logger.Log(1, fmt.Sprintf("----> Peer Endpoint has changed from %s to %s",
 					currentPeer.Config.PeerConf.Endpoint.String(), m.Peers[i].Endpoint.String()))
 				logger.Log(1, "----------> Resetting proxy for Peer: ", currentPeer.Key.String())
@@ -324,7 +327,7 @@ func (m *proxyPayload) processPayload() error {
 				continue
 
 			}
-			if !config.GetCfg().IsGlobalRelay() && !currentPeer.IsRelayed && currentPeer.Config.RemoteConnAddr.IP.String() != m.Peers[i].Endpoint.IP.String() {
+			if !config.GetCfg().IsGlobalRelay() && !currentPeer.IsRelayed && m.Peers[i].Endpoint != nil && currentPeer.Config.RemoteConnAddr.IP.String() != m.Peers[i].Endpoint.IP.String() {
 				logger.Log(1, fmt.Sprintf("----> Peer RemoteConn has changed from %s to %s",
 					currentPeer.Config.RemoteConnAddr.String(), m.Peers[i].Endpoint.String()))
 				logger.Log(1, "----------> Resetting proxy for Peer: ", currentPeer.Key.String())
@@ -359,7 +362,7 @@ func (m *proxyPayload) processPayload() error {
 			if err == nil {
 				logger.Log(3, fmt.Sprintf("--------->[noProxy] comparing peer endpoint: onDevice: %s, Proxy: %s", devPeer.Endpoint.String(),
 					noProxypeer.Config.LocalConnAddr.String()))
-				if devPeer.Endpoint.String() != noProxypeer.Config.LocalConnAddr.String() {
+				if devPeer.Endpoint != nil && devPeer.Endpoint.String() != noProxypeer.Config.LocalConnAddr.String() {
 					logger.Log(1, "---------> endpoint is not set to proxy: ", noProxypeer.Key.String())
 					noProxypeer.StopConn()
 					noProxypeer.Mutex.Unlock()

--- a/nmproxy/peer/peer.go
+++ b/nmproxy/peer/peer.go
@@ -160,6 +160,9 @@ func collectMetricsForServerPeers(server string, peerIDAndAddrMap nm_models.Host
 				proxyListenPort = peerInfo.ProxyListenPort
 				metric.NodeConnectionStatus[peerID] = connectionStatus
 			}
+			if peer.Endpoint == nil {
+				continue
+			}
 			proxyConn, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", peer.Endpoint.IP.String(), proxyListenPort))
 			if err != nil {
 				continue

--- a/nmproxy/server/server.go
+++ b/nmproxy/server/server.go
@@ -213,7 +213,7 @@ func (p *ProxyServer) handleMsgs(buffer []byte, n int, source *net.UDPAddr) {
 		peerKey, err := packet.ConsumeHandshakeInitiationMsg(false, buffer[:n],
 			packet.NoisePublicKey(pub), packet.NoisePrivateKey(priv))
 		if err != nil {
-			logger.Log(1, "---------> @@@ failed to decode HS: ", err.Error())
+			logger.Log(4, "---------> @@@ failed to decode HS: ", err.Error())
 		} else {
 
 			logger.Log(1, "--------> Got HandShake from peer: ", peerKey, source.String())


### PR DESCRIPTION
## Describe your changes
nil checks are added for peer endpoint to avoid nil pointer errors
## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

- [ ] Make sure after adding ext clients to a node, no nil pointer errors occur on running list command
- [ ] On peer updates, no nil pointer errors occur after adding ext clients

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
