### PR TITLE
change network name to netmaker from terraform

### DIFF
--- a/.github/workflows/branchtest.yml
+++ b/.github/workflows/branchtest.yml
@@ -52,6 +52,6 @@ jobs:
     uses: gravitl/devops/.github/workflows/branchtest.yml@master
     with:
       tag: ${{ github.run_id }}-${{ github.run_attempt }}
-      network: terraform
+      network: netmaker
     secrets: inherit
     


### PR DESCRIPTION
## Describe your changes
changing the network name to netmaker since terraform no longer makes a terraform network in branchtest.yml

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [x] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
