### PR TITLE
fixed data endcoding

### DIFF
--- a/networking/server-pong.go
+++ b/networking/server-pong.go
@@ -68,8 +68,8 @@ func handleRequest(c net.Conn) {
 	if len(request.Hash) > 0 { // publickeyhash + time
 		pubKeyHash := request.Hash
 		currenHostPubKey := config.Netclient().PublicKey.String()
-		currentHostPubKeyHash := sha1.Sum([]byte(currenHostPubKey))
-		if pubKeyHash == string(currentHostPubKeyHash[:]) {
+		currentHostPubKeyHashString := fmt.Sprintf("%v", sha1.Sum([]byte(currenHostPubKey)))
+		if pubKeyHash == string(currentHostPubKeyHashString) {
 			sendError(c)
 			return
 		}

--- a/networking/server-pong.go
+++ b/networking/server-pong.go
@@ -69,7 +69,7 @@ func handleRequest(c net.Conn) {
 		pubKeyHash := request.Hash
 		currenHostPubKey := config.Netclient().PublicKey.String()
 		currentHostPubKeyHashString := fmt.Sprintf("%v", sha1.Sum([]byte(currenHostPubKey)))
-		if pubKeyHash == string(currentHostPubKeyHashString) {
+		if pubKeyHash == currentHostPubKeyHashString {
 			sendError(c)
 			return
 		}


### PR DESCRIPTION
## Describe your changes

Fixed issue with client-pong improperly converting byte data to runes. Incorrect encoding led to always returning a "!=" when receiving a client-ping, meaning a host can ping itself, receive a success response, and set a local interface as the interface.

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

1. Create a dummy interface with the same ip address on two clients with the current release **before registering with the server:**
```
ip link add dummy1 type dummy
ip addr add 10.11.12.13/24 dev dummy1
ip link set dummy1 up
```
2. Register the clients with the server
3. Both clients should set the other clients' endpoint to 10.11.12.13 after ~5 minutes (look at wg)
4. unregister the clients and stop the daemon if still running. Delete the wireguard interface if it exists
5. install the new netclient from this branch
6. re-register the clients
7. See that the clients **do not** set 10.11.12.13 as the endpoint (wait at least 5 minutes)

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
