### PR TITLE
NET-185 Dont re-use the Config struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ gui/build/
 gui/**/dist/
 backup/*
 dist/*
+/.idea

--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,7 @@ func ReadNetclientConfig() (*Config, error) {
 		return nil, err
 	}
 	defer f.Close()
+	netclient = Config{}
 	if err := yaml.NewDecoder(f).Decode(&netclient); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes

NET-185 Dont re-use the Config struct.

## Provide testing steps

https://toil.kitemaker.co/cQARgD-Gravitl/6a50SD-Netmaker/items/185

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netclient & Netmaker are awesome.
