### PR TITLE
NET-176: Support Only Single Server at a time

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -64,7 +64,7 @@ func cleanUpByServer(server *config.Server) error {
 	if _, err := config.ReadNetclientConfig(); err != nil {
 		return err
 	}
-	serverNodes := config.GetNodesByServer(server.Name)
+	serverNodes := config.GetNodes()
 	for i := range serverNodes {
 		node := serverNodes[i]
 		config.DeleteNode(node.Network)
@@ -73,7 +73,7 @@ func cleanUpByServer(server *config.Server) error {
 		return err
 	}
 	config.RemoveServerHostPeerCfg()
-	if err := wireguard.SetPeers(); err != nil {
+	if err := wireguard.SetPeers(true); err != nil {
 		logger.Log(0, "interface not up, failed to remove peers for %s \n", server.Name)
 	}
 	if err := routes.CleanUp(config.Netclient().DefaultInterface, nil); err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -79,7 +79,7 @@ func cleanUpByServer(server *config.Server) error {
 	if err := routes.CleanUp(config.Netclient().DefaultInterface, nil); err != nil {
 		return err
 	}
-	config.DeleteServerHostPeerCfg(server.Name)
+	config.DeleteServerHostPeerCfg()
 	if err := config.WriteNetclientConfig(); err != nil {
 		return err
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -72,7 +72,7 @@ func cleanUpByServer(server *config.Server) error {
 	if err := config.WriteNodeConfig(); err != nil {
 		return err
 	}
-	config.RemoveServerHostPeerCfg(server.Name)
+	config.RemoveServerHostPeerCfg()
 	if err := wireguard.SetPeers(); err != nil {
 		logger.Log(0, "interface not up, failed to remove peers for %s \n", server.Name)
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -16,7 +16,7 @@ var pullCmd = &cobra.Command{
 	Short: "get the latest host configuration",
 	Long:  `get the latest host configuration and peers from all connected servers`,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := functions.Pull()
+		err := functions.Pull(true)
 		if err != nil {
 			logger.Log(0, "failed to pull", err.Error())
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// installCmd represents the install command
-var setCtx = &cobra.Command{
+// switchServer command is used to set netclient context to a server, it has registered already.
+var switchServer = &cobra.Command{
 	Use:   "switch [ servername ]",
 	Short: "switch [ servername ]",
 	Long:  `sets  netclient to a server config`,
@@ -27,15 +27,5 @@ var setCtx = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(setCtx)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// installCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// installCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.AddCommand(switchServer)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gravitl/netclient/functions"
+	"github.com/spf13/cobra"
+)
+
+// installCmd represents the install command
+var setCtx = &cobra.Command{
+	Use:   "switch [ servername ]",
+	Short: "switch [ servername ]",
+	Long:  `sets  netclient to a server config`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		err := cobra.OnlyValidArgs(cmd, args)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		err = functions.SwitchServer(args[0])
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(setCtx)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// installCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// installCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -11,7 +11,7 @@ import (
 var switchServer = &cobra.Command{
 	Use:   "switch [ servername ]",
 	Short: "switch [ servername ]",
-	Long:  `sets  netclient to a server config`,
+	Long:  `switches netclient to a registered server`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cobra.OnlyValidArgs(cmd, args)

--- a/config/config.go
+++ b/config/config.go
@@ -111,15 +111,15 @@ func Netclient() *Config {
 }
 
 // GetHostPeerList - gets the combined list of peers for the host
-func GetHostPeerList() (allPeers []wgtypes.PeerConfig) {
+func GetHostPeerList() []wgtypes.PeerConfig {
 	hostPeers := netclient.HostPeers
 	return hostPeers
 }
 
 // UpdateHostPeers - updates host peer map in the netclient config
-func UpdateHostPeers(server string, peers []wgtypes.PeerConfig) (isHostInetGW bool) {
+func UpdateHostPeers(peers []wgtypes.PeerConfig) (isHostInetGW bool) {
 	netclient.HostPeers = peers
-	return detectOrFilterGWPeers(server, peers)
+	return detectOrFilterGWPeers(peers)
 }
 
 // DeleteServerHostPeerCfg - deletes the host peers for the server
@@ -128,7 +128,7 @@ func DeleteServerHostPeerCfg() {
 }
 
 // RemoveServerHostPeerCfg - sets remove flag for all peers on the given server peers
-func RemoveServerHostPeerCfg(serverName string) {
+func RemoveServerHostPeerCfg() {
 	if netclient.HostPeers == nil {
 		netclient.HostPeers = []wgtypes.PeerConfig{}
 		return
@@ -571,7 +571,7 @@ func Convert(h *Config, n *Node) (models.Host, models.Node) {
 	return host, node
 }
 
-func detectOrFilterGWPeers(server string, peers []wgtypes.PeerConfig) bool {
+func detectOrFilterGWPeers(peers []wgtypes.PeerConfig) bool {
 	isInetGW := IsHostInetGateway()
 	if len(peers) > 0 {
 		if GW4PeerDetected || GW6PeerDetected { // check if there is a change in GWs before proceeding

--- a/config/config.go
+++ b/config/config.go
@@ -63,15 +63,14 @@ var (
 // Config configuration for netclient and host as a whole
 type Config struct {
 	models.Host
-	PrivateKey        wgtypes.Key                     `json:"privatekey" yaml:"privatekey"`
-	TrafficKeyPrivate []byte                          `json:"traffickeyprivate" yaml:"traffickeyprivate"`
-	HostPeers         map[string][]wgtypes.PeerConfig `json:"peers" yaml:"peers"`
+	PrivateKey        wgtypes.Key          `json:"privatekey" yaml:"privatekey"`
+	TrafficKeyPrivate []byte               `json:"traffickeyprivate" yaml:"traffickeyprivate"`
+	HostPeers         []wgtypes.PeerConfig `json:"peers_info" yaml:"peers_info"`
 }
 
 func init() {
 	Servers = make(map[string]Server)
 	Nodes = make(map[string]Node)
-	netclient.HostPeers = make(map[string][]wgtypes.PeerConfig)
 }
 
 // UpdateNetcllient updates the in memory version of the host configuration
@@ -112,74 +111,35 @@ func Netclient() *Config {
 
 // GetHostPeerList - gets the combined list of peers for the host
 func GetHostPeerList() (allPeers []wgtypes.PeerConfig) {
-	hostPeerMap := netclient.HostPeers
-	peerMap := make(map[string]int)
-	for _, serverPeers := range hostPeerMap {
-		serverPeers := serverPeers
-		for i, peerI := range serverPeers {
-			peerI := peerI
-			if ind, ok := peerMap[peerI.PublicKey.String()]; ok {
-				allPeers[ind].AllowedIPs = getUniqueAllowedIPList(allPeers[ind].AllowedIPs, peerI.AllowedIPs)
-			} else {
-				peerMap[peerI.PublicKey.String()] = i
-				allPeers = append(allPeers, peerI)
-			}
-
-		}
-	}
-	return
+	hostPeers := netclient.HostPeers
+	return hostPeers
 }
 
 // UpdateHostPeers - updates host peer map in the netclient config
 func UpdateHostPeers(server string, peers []wgtypes.PeerConfig) (isHostInetGW bool) {
-	hostPeerMap := netclient.HostPeers
-	if hostPeerMap == nil {
-		hostPeerMap = make(map[string][]wgtypes.PeerConfig, 1)
-	}
-	hostPeerMap[server] = peers
-	netclient.HostPeers = hostPeerMap
+	netclient.HostPeers = peers
 	return detectOrFilterGWPeers(server, peers)
 }
 
 // DeleteServerHostPeerCfg - deletes the host peers for the server
-func DeleteServerHostPeerCfg(server string) {
-	if netclient.HostPeers == nil {
-		netclient.HostPeers = make(map[string][]wgtypes.PeerConfig)
-		return
-	}
-	delete(netclient.HostPeers, server)
+func DeleteServerHostPeerCfg() {
+	netclient.HostPeers = make([]wgtypes.PeerConfig, 0)
 }
 
 // RemoveServerHostPeerCfg - sets remove flag for all peers on the given server peers
 func RemoveServerHostPeerCfg(serverName string) {
 	if netclient.HostPeers == nil {
-		netclient.HostPeers = make(map[string][]wgtypes.PeerConfig)
+		netclient.HostPeers = []wgtypes.PeerConfig{}
 		return
 	}
-	peers := netclient.HostPeers[serverName]
+	peers := netclient.HostPeers
 	for i := range peers {
 		peer := peers[i]
 		peer.Remove = true
 		peers[i] = peer
 	}
-	netclient.HostPeers[serverName] = peers
+	netclient.HostPeers = peers
 	_ = WriteNetclientConfig()
-}
-
-func getUniqueAllowedIPList(currIps, newIps []net.IPNet) []net.IPNet {
-	uniqueIpList := []net.IPNet{}
-	ipMap := make(map[string]struct{})
-	uniqueIpList = append(uniqueIpList, currIps...)
-	uniqueIpList = append(uniqueIpList, newIps...)
-	for i := len(uniqueIpList) - 1; i >= 0; i-- {
-		if _, ok := ipMap[uniqueIpList[i].String()]; ok {
-			// if ip already exists, remove duplicate one
-			uniqueIpList = append(uniqueIpList[:i], uniqueIpList[i+1:]...)
-		} else {
-			ipMap[uniqueIpList[i].String()] = struct{}{}
-		}
-	}
-	return uniqueIpList
 }
 
 // SetVersion - sets version for use by other packages
@@ -436,6 +396,7 @@ func InitConfig(viper *viper.Viper) {
 	ReadNodeConfig()
 	ReadServerConf()
 	CheckConfig()
+	SetServerCtx()
 	//check netclient dirs exist
 	if _, err := os.Stat(GetNetclientPath()); err != nil {
 		if os.IsNotExist(err) {
@@ -679,21 +640,19 @@ func peerHasIp(ip *net.IPNet, allowedIPs []net.IPNet) bool {
 // IsHostInetGateway - checks, based on netclient memory,
 // if current client is an internet gateway
 func IsHostInetGateway() bool {
-	servers := GetServers()
-	for i := range servers {
-		serverName := servers[i]
-		serverNodes := GetNodesByServer(serverName)
-		for j := range serverNodes {
-			serverNode := serverNodes[j]
-			if serverNode.IsEgressGateway {
-				for _, egressRange := range serverNode.EgressGatewayRanges {
-					if egressRange == "0.0.0.0/0" || egressRange == "::/0" {
-						return true
-					}
+
+	serverNodes := GetNodesByServer(CurrServer)
+	for j := range serverNodes {
+		serverNode := serverNodes[j]
+		if serverNode.IsEgressGateway {
+			for _, egressRange := range serverNode.EgressGatewayRanges {
+				if egressRange == "0.0.0.0/0" || egressRange == "::/0" {
+					return true
 				}
 			}
 		}
 	}
+
 	return false
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 func init() {
 	Servers = make(map[string]Server)
 	Nodes = make(map[string]Node)
+
 }
 
 // UpdateNetcllient updates the in memory version of the host configuration

--- a/config/config.go
+++ b/config/config.go
@@ -390,8 +390,8 @@ func InitConfig(viper *viper.Viper) {
 	setLogVerbosity(viper)
 	ReadNodeConfig()
 	ReadServerConf()
-	CheckConfig()
 	SetServerCtx()
+	CheckConfig()
 	//check netclient dirs exist
 	if _, err := os.Stat(GetNetclientPath()); err != nil {
 		if os.IsNotExist(err) {
@@ -523,20 +523,15 @@ func CheckConfig() {
 		}
 	}
 	_ = ReadServerConf()
-	for _, server := range Servers {
+	_ = ReadNodeConfig()
+	server := GetServer(CurrServer)
+	if server == nil {
+		fail = true
+		logger.Log(0, "configuration for", CurrServer, "is missing")
+	} else {
 		if server.MQID != netclient.ID {
 			fail = true
 			logger.Log(0, server.Name, "is misconfigured: MQID/Password does not match hostid/password")
-		}
-	}
-	_ = ReadNodeConfig()
-	nodes := GetNodes()
-	for _, node := range nodes {
-		//make sure server config exists
-		server := GetServer(node.Server)
-		if server == nil {
-			fail = true
-			logger.Log(0, "configuration for", node.Server, "is missing")
 		}
 	}
 	if fail {
@@ -636,7 +631,7 @@ func peerHasIp(ip *net.IPNet, allowedIPs []net.IPNet) bool {
 // if current client is an internet gateway
 func IsHostInetGateway() bool {
 
-	serverNodes := GetNodesByServer(CurrServer)
+	serverNodes := GetNodes()
 	for j := range serverNodes {
 		serverNode := serverNodes[j]
 		if serverNode.IsEgressGateway {

--- a/config/config.go
+++ b/config/config.go
@@ -524,16 +524,19 @@ func CheckConfig() {
 	}
 	_ = ReadServerConf()
 	_ = ReadNodeConfig()
-	server := GetServer(CurrServer)
-	if server == nil {
-		fail = true
-		logger.Log(0, "configuration for", CurrServer, "is missing")
-	} else {
-		if server.MQID != netclient.ID {
+	if CurrServer != "" {
+		server := GetServer(CurrServer)
+		if server == nil {
 			fail = true
-			logger.Log(0, server.Name, "is misconfigured: MQID/Password does not match hostid/password")
+			logger.Log(0, "configuration for", CurrServer, "is missing")
+		} else {
+			if server.MQID != netclient.ID {
+				fail = true
+				logger.Log(0, server.Name, "is misconfigured: MQID/Password does not match hostid/password")
+			}
 		}
 	}
+
 	if fail {
 		logger.FatalLog("configuration is invalid, fix before proceeding")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -110,12 +110,6 @@ func Netclient() *Config {
 	return &netclient
 }
 
-// GetHostPeerList - gets the combined list of peers for the host
-func GetHostPeerList() []wgtypes.PeerConfig {
-	hostPeers := netclient.HostPeers
-	return hostPeers
-}
-
 // UpdateHostPeers - updates host peer map in the netclient config
 func UpdateHostPeers(peers []wgtypes.PeerConfig) (isHostInetGW bool) {
 	netclient.HostPeers = peers
@@ -587,7 +581,7 @@ func detectOrFilterGWPeers(peers []wgtypes.PeerConfig) bool {
 			}
 		}
 	}
-	clientPeers := GetHostPeerList()
+	clientPeers := netclient.HostPeers
 	var foundGW4Again, foundGW6Again bool
 	if len(clientPeers) > 0 {
 		for i := range clientPeers {

--- a/config/node.go
+++ b/config/node.go
@@ -64,16 +64,14 @@ func GetNode(k string) Node {
 	return Node{}
 }
 
-// GetNodesByServer returns a copy of nodes that belong to a certain server
-func GetNodesByServer(serverName string) []Node {
-	nodes := []Node{}
-	for k := range Nodes {
-		currNode := Nodes[k]
-		if currNode.Server == serverName {
-			nodes = append(nodes, currNode)
+// SetNodes - sets server nodes in client config
+func SetNodes(nodes []models.Node) {
+	Nodes = make(NodeMap)
+	for _, node := range nodes {
+		Nodes[node.Network] = Node{
+			CommonNode: node.CommonNode,
 		}
 	}
-	return nodes
 }
 
 // UpdateNodeMap updates the in memory nodemap for the specified network

--- a/config/server.go
+++ b/config/server.go
@@ -143,14 +143,14 @@ func GetCurrServerCtxFromFile() (string, error) {
 	return string(d), nil
 }
 
-// SetCurrServerCtxInFile - sets the Curr context in the file
+// SetCurrServerCtxInFile - sets the curr context in the file
 func SetCurrServerCtxInFile(server string) error {
 	return ioutil.WriteFile(filepath.Join(GetNetclientPath(), serverCtxFile), []byte(server), os.ModePerm)
 }
 
 // SetServerCtx - sets netclient's server context
 func SetServerCtx() {
-	// set server context on startup
+	// sets server context on startup
 	currServer, err := GetCurrServerCtxFromFile()
 	if err != nil || currServer == "" {
 		servers := GetServers()

--- a/config/server.go
+++ b/config/server.go
@@ -150,15 +150,24 @@ func SetCurrServerCtxInFile(server string) error {
 // SetServerCtx - sets netclient's server context
 func SetServerCtx() {
 	// sets server context on startup
+	setDefault := false
 	currServer, err := GetCurrServerCtxFromFile()
 	if err != nil || currServer == "" {
+		setDefault = true
+	} else {
+		if GetServer(currServer) == nil {
+			setDefault = true
+		} else {
+			CurrServer = currServer
+		}
+
+	}
+	if setDefault {
 		servers := GetServers()
 		if len(servers) > 0 {
 			CurrServer = servers[0]
 			SetCurrServerCtxInFile(CurrServer)
 		}
-	} else {
-		CurrServer = currServer
 	}
 }
 

--- a/config/server.go
+++ b/config/server.go
@@ -14,6 +14,8 @@ import (
 )
 
 var serverCtxFile = ".serverctx"
+
+// CurrServer - holds the value of current server of client
 var CurrServer string
 
 // Servers is map of servers indexed by server name

--- a/config/server.go
+++ b/config/server.go
@@ -134,7 +134,7 @@ func GetServers() (servers []string) {
 	return
 }
 
-// GetCurrServerCtxFromFile - gets curr server context from file
+// GetCurrServerCtxFromFile - gets current server context from file
 func GetCurrServerCtxFromFile() (string, error) {
 	d, err := ioutil.ReadFile(filepath.Join(GetNetclientPath(), serverCtxFile))
 	if err != nil {
@@ -143,7 +143,7 @@ func GetCurrServerCtxFromFile() (string, error) {
 	return string(d), nil
 }
 
-// SetCurrServerCtxInFile - sets the curr context in the file
+// SetCurrServerCtxInFile - sets the current server context in the file
 func SetCurrServerCtxInFile(server string) error {
 	return ioutil.WriteFile(filepath.Join(GetNetclientPath(), serverCtxFile), []byte(server), os.ModePerm)
 }

--- a/config/server.go
+++ b/config/server.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,7 +135,7 @@ func GetServers() (servers []string) {
 
 // GetCurrServerCtxFromFile - gets current server context from file
 func GetCurrServerCtxFromFile() (string, error) {
-	d, err := ioutil.ReadFile(filepath.Join(GetNetclientPath(), serverCtxFile))
+	d, err := os.ReadFile(filepath.Join(GetNetclientPath(), serverCtxFile))
 	if err != nil {
 		return "", err
 	}
@@ -145,7 +144,7 @@ func GetCurrServerCtxFromFile() (string, error) {
 
 // SetCurrServerCtxInFile - sets the current server context in the file
 func SetCurrServerCtxInFile(server string) error {
-	return ioutil.WriteFile(filepath.Join(GetNetclientPath(), serverCtxFile), []byte(server), os.ModePerm)
+	return os.WriteFile(filepath.Join(GetNetclientPath(), serverCtxFile), []byte(server), os.ModePerm)
 }
 
 // SetServerCtx - sets netclient's server context

--- a/functions/connect.go
+++ b/functions/connect.go
@@ -24,6 +24,9 @@ func Disconnect(network string) error {
 		return fmt.Errorf("error writing node config %w", err)
 	}
 	server := config.GetServer(node.Server)
+	if server == nil {
+		return errors.New("server cfg is nil")
+	}
 	if err := setupMQTTSingleton(server, true); err != nil {
 		return err
 	}
@@ -55,6 +58,9 @@ func Connect(network string) error {
 		return fmt.Errorf("error writing node config %w", err)
 	}
 	server := config.GetServer(node.Server)
+	if server == nil {
+		return errors.New("server cfg is nil")
+	}
 	if err := setupMQTTSingleton(server, true); err != nil {
 		return err
 	}

--- a/functions/context.go
+++ b/functions/context.go
@@ -1,0 +1,34 @@
+package functions
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gravitl/netclient/config"
+	"github.com/gravitl/netclient/daemon"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// SwitchServer - switch netclient server context
+func SwitchServer(server string) error {
+	fmt.Println("setting context to " + server)
+	if config.GetServer(server) == nil {
+		return errors.New("server config not found")
+	}
+	currServerCtx, err := config.GetCurrServerCtxFromFile()
+	if err == nil {
+		if server == currServerCtx {
+			fmt.Println("netclient already switched to " + server + " context")
+			return nil
+		}
+	}
+
+	err = config.SetCurrServerCtxInFile(server)
+	if err != nil {
+		fmt.Println("failed to set server context ", err)
+		return err
+	}
+	config.Netclient().HostPeers = []wgtypes.PeerConfig{}
+	config.WriteNetclientConfig()
+	return daemon.Restart()
+}

--- a/functions/context.go
+++ b/functions/context.go
@@ -9,7 +9,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-// SwitchServer - switch netclient server context
+// SwitchServer - switches netclient server context
 func SwitchServer(server string) error {
 	fmt.Println("setting context to " + server)
 	if config.GetServer(server) == nil {
@@ -29,6 +29,6 @@ func SwitchServer(server string) error {
 		return err
 	}
 	config.Netclient().HostPeers = []wgtypes.PeerConfig{}
-	config.WriteNetclientConfig()
+	_ = config.WriteNetclientConfig()
 	return daemon.Restart()
 }

--- a/functions/context.go
+++ b/functions/context.go
@@ -11,7 +11,7 @@ import (
 
 // SwitchServer - switches netclient server context
 func SwitchServer(server string) error {
-	fmt.Println("setting server context to " + server)
+	fmt.Println("setting netclient server context to " + server)
 	if config.GetServer(server) == nil {
 		return errors.New("server config not found")
 	}

--- a/functions/context.go
+++ b/functions/context.go
@@ -11,7 +11,7 @@ import (
 
 // SwitchServer - switches netclient server context
 func SwitchServer(server string) error {
-	fmt.Println("setting context to " + server)
+	fmt.Println("setting server context to " + server)
 	if config.GetServer(server) == nil {
 		return errors.New("server config not found")
 	}

--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -143,15 +143,17 @@ func startGoRoutines(wg *sync.WaitGroup) context.CancelFunc {
 			},
 		}
 	}
+
+	Pull(false)
+	nc := wireguard.NewNCIface(config.Netclient(), config.GetNodes())
+	nc.Create()
+	nc.Configure()
+	wireguard.SetPeers(true)
 	server := config.GetServer(config.CurrServer)
 	if server == nil {
 		return cancel
 	}
 	logger.Log(1, "started daemon for server ", server.Name)
-	Pull(false)
-	nc := wireguard.NewNCIface(config.Netclient(), config.GetNodes())
-	nc.Create()
-	nc.Configure()
 	networking.StoreServerAddresses(server)
 	err := routes.SetNetmakerServerRoutes(config.Netclient().DefaultInterface, server)
 	if err != nil {
@@ -159,7 +161,6 @@ func startGoRoutines(wg *sync.WaitGroup) context.CancelFunc {
 	}
 	wg.Add(1)
 	go messageQueue(ctx, wg, server)
-	wireguard.SetPeers(true)
 	if err := routes.SetNetmakerPeerEndpointRoutes(config.Netclient().DefaultInterface); err != nil {
 		logger.Log(2, "failed to set initial peer routes", err.Error())
 	}

--- a/functions/httpserver.go
+++ b/functions/httpserver.go
@@ -199,7 +199,7 @@ func uninstall(c *gin.Context) {
 
 func pull(c *gin.Context) {
 	net := c.Params.ByName("net")
-	err := Pull()
+	err := Pull(true)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
 	}

--- a/functions/httpserver.go
+++ b/functions/httpserver.go
@@ -100,8 +100,12 @@ func getNetwork(c *gin.Context) {
 	for _, node := range nodes {
 		node := node
 		if node.Network == network {
-			server := *config.GetServer(node.Server)
-			c.JSON(http.StatusOK, Network{node, server})
+			server := config.GetServer(node.Server)
+			if server == nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "server config not found"})
+				return
+			}
+			c.JSON(http.StatusOK, Network{node, *server})
 			return
 		}
 	}
@@ -114,6 +118,10 @@ func getAllNetworks(c *gin.Context) {
 	for _, node := range nodes {
 		node := node
 		server := config.GetServer(node.Server)
+		if server == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "server config not found"})
+			return
+		}
 		configs = append(configs, Network{node, *server})
 	}
 	c.JSON(http.StatusOK, configs)
@@ -197,6 +205,10 @@ func pull(c *gin.Context) {
 	}
 	node := config.GetNode(net)
 	server := config.GetServer(node.Server)
+	if server == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "server config not found"})
+		return
+	}
 	network := Network{
 		Node:   node,
 		Server: *server,

--- a/functions/list.go
+++ b/functions/list.go
@@ -36,10 +36,9 @@ func List(net string, long bool) {
 	listOutput := []output{}
 	found := false
 	nodes := config.GetNodes()
-	for network := range nodes {
-		if network == net || net == "" {
+	for _, node := range nodes {
+		if node.Network == net || net == "" {
 			found = true
-			node := nodes[network]
 			output := output{
 				Network:   node.Network,
 				Connected: node.Connected,

--- a/functions/list.go
+++ b/functions/list.go
@@ -94,6 +94,9 @@ func List(net string, long bool) {
 func GetNodePeers(node config.Node) ([]wgtypes.PeerConfig, error) {
 
 	server := config.GetServer(node.Server)
+	if server == nil {
+		return []wgtypes.PeerConfig{}, errors.New("server config not found")
+	}
 	host := config.Netclient()
 	if host == nil {
 		return nil, fmt.Errorf("no configured host found")

--- a/functions/migrate.go
+++ b/functions/migrate.go
@@ -161,6 +161,9 @@ func Migrate() {
 		serverValue := serversToWrite[i]
 		config.UpdateServerConfig(&serverValue)
 		newServerConfig := config.GetServer(serverValue.Server)
+		if newServerConfig == nil {
+			continue
+		}
 		config.UpdateServer(serverValue.Server, *newServerConfig)
 		if err := config.SaveServer(serverValue.Server, *newServerConfig); err != nil {
 			logger.Log(0, "failed to save server", err.Error())

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -221,7 +221,7 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 		deleteHostCfg(client, serverName)
 		config.WriteNodeConfig()
 		config.WriteServerConfig()
-		resetInterface = true
+		restartDaemon = true
 	case models.UpdateHost:
 		resetInterface, restartDaemon = updateHostConfig(&hostUpdate.Host)
 		clearMsg = true

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -309,7 +309,7 @@ func handleEndpointDetection(peerUpdate *models.HostPeerUpdate) {
 }
 
 func deleteHostCfg(client mqtt.Client, server string) {
-	config.DeleteServerHostPeerCfg(server)
+	config.DeleteServerHostPeerCfg()
 	nodes := config.GetNodes()
 	for k, node := range nodes {
 		node := node
@@ -319,8 +319,6 @@ func deleteHostCfg(client mqtt.Client, server string) {
 		}
 	}
 	config.DeleteServer(server)
-	// delete mq client from ServerSet map
-	delete(ServerSet, server)
 }
 
 func updateHostConfig(host *models.Host) (resetInterface, restart bool) {

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -146,7 +146,7 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 	currentGW6 := config.GW6Addr
 	isInetGW := config.UpdateHostPeers(peerUpdate.Peers)
 	_ = config.WriteNetclientConfig()
-	_ = wireguard.SetPeers()
+	_ = wireguard.SetPeers(false)
 	wireguard.GetInterface().GetPeerRoutes()
 	if err = routes.SetNetmakerPeerEndpointRoutes(config.Netclient().DefaultInterface); err != nil {
 		logger.Log(0, "error when setting peer routes after peer update", err.Error())
@@ -263,7 +263,7 @@ func HostUpdate(client mqtt.Client, msg mqtt.Message) {
 			return
 		}
 
-		if err = wireguard.SetPeers(); err == nil {
+		if err = wireguard.SetPeers(false); err == nil {
 			if err = routes.SetNetmakerPeerEndpointRoutes(config.Netclient().DefaultInterface); err != nil {
 				logger.Log(0, "error when setting peer routes after host update", err.Error())
 			}

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -144,7 +144,7 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 	gwDetected := config.GW4PeerDetected || config.GW6PeerDetected
 	currentGW4 := config.GW4Addr
 	currentGW6 := config.GW6Addr
-	isInetGW := config.UpdateHostPeers(serverName, peerUpdate.Peers)
+	isInetGW := config.UpdateHostPeers(peerUpdate.Peers)
 	_ = config.WriteNetclientConfig()
 	_ = wireguard.SetPeers()
 	wireguard.GetInterface().GetPeerRoutes()

--- a/functions/mqpublish.go
+++ b/functions/mqpublish.go
@@ -249,7 +249,7 @@ func UpdateHostSettings() error {
 		publishMsg = true
 	}
 	if server.Is_EE {
-		serverNodes := config.GetNodesByServer(config.CurrServer)
+		serverNodes := config.GetNodes()
 		for _, node := range serverNodes {
 			node := node
 			if node.Connected {

--- a/functions/pull.go
+++ b/functions/pull.go
@@ -41,7 +41,7 @@ func Pull() error {
 		}
 		return err
 	}
-	_ = config.UpdateHostPeers(server.Server, pullResponse.Peers)
+	_ = config.UpdateHostPeers(pullResponse.Peers)
 	pullResponse.ServerConfig.MQPassword = server.MQPassword // pwd can't change currently
 	config.UpdateServerConfig(&pullResponse.ServerConfig)
 	fmt.Printf("completed pull for server %s\n", serverName)

--- a/functions/pull.go
+++ b/functions/pull.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Pull - pulls the latest config from the server, if manual it will overwrite
-func Pull() error {
+func Pull(restart bool) error {
 
 	serverName := config.CurrServer
 	server := config.GetServer(serverName)
@@ -44,10 +44,14 @@ func Pull() error {
 	_ = config.UpdateHostPeers(pullResponse.Peers)
 	pullResponse.ServerConfig.MQPassword = server.MQPassword // pwd can't change currently
 	config.UpdateServerConfig(&pullResponse.ServerConfig)
+	config.SetNodes(pullResponse.Nodes)
 	fmt.Printf("completed pull for server %s\n", serverName)
-
 	_ = config.WriteServerConfig()
 	_ = config.WriteNetclientConfig()
-	logger.Log(3, "restarting daemon")
-	return daemon.Restart()
+	_ = config.WriteNodeConfig()
+	if restart {
+		logger.Log(3, "restarting daemon")
+		return daemon.Restart()
+	}
+	return nil
 }

--- a/functions/pull.go
+++ b/functions/pull.go
@@ -17,34 +17,35 @@ import (
 // Pull - pulls the latest config from the server, if manual it will overwrite
 func Pull() error {
 
-	currentServers := config.GetServers()
-	for i := range currentServers {
-		serverName := currentServers[i]
-		server := config.GetServer(serverName)
-		token, err := auth.Authenticate(server, config.Netclient())
-		if err != nil {
-			return err
-		}
-		endpoint := httpclient.JSONEndpoint[models.HostPull, models.ErrorResponse]{
-			URL:           "https://" + server.API,
-			Route:         "/api/v1/host",
-			Method:        http.MethodGet,
-			Authorization: "Bearer " + token,
-			Response:      models.HostPull{},
-			ErrorResponse: models.ErrorResponse{},
-		}
-		pullResponse, errData, err := endpoint.GetJSON(models.HostPull{}, models.ErrorResponse{})
-		if err != nil {
-			if errors.Is(err, httpclient.ErrStatus) {
-				logger.Log(0, "error pulling server", serverName, strconv.Itoa(errData.Code), errData.Message)
-			}
-			continue
-		}
-		_ = config.UpdateHostPeers(server.Server, pullResponse.Peers)
-		pullResponse.ServerConfig.MQPassword = server.MQPassword // pwd can't change currently
-		config.UpdateServerConfig(&pullResponse.ServerConfig)
-		fmt.Printf("completed pull for server %s\n", serverName)
+	serverName := config.CurrServer
+	server := config.GetServer(serverName)
+	if server == nil {
+		return errors.New("server config not found")
 	}
+	token, err := auth.Authenticate(server, config.Netclient())
+	if err != nil {
+		return err
+	}
+	endpoint := httpclient.JSONEndpoint[models.HostPull, models.ErrorResponse]{
+		URL:           "https://" + server.API,
+		Route:         "/api/v1/host",
+		Method:        http.MethodGet,
+		Authorization: "Bearer " + token,
+		Response:      models.HostPull{},
+		ErrorResponse: models.ErrorResponse{},
+	}
+	pullResponse, errData, err := endpoint.GetJSON(models.HostPull{}, models.ErrorResponse{})
+	if err != nil {
+		if errors.Is(err, httpclient.ErrStatus) {
+			logger.Log(0, "error pulling server", serverName, strconv.Itoa(errData.Code), errData.Message)
+		}
+		return err
+	}
+	_ = config.UpdateHostPeers(server.Server, pullResponse.Peers)
+	pullResponse.ServerConfig.MQPassword = server.MQPassword // pwd can't change currently
+	config.UpdateServerConfig(&pullResponse.ServerConfig)
+	fmt.Printf("completed pull for server %s\n", serverName)
+
 	_ = config.WriteServerConfig()
 	_ = config.WriteNetclientConfig()
 	logger.Log(3, "restarting daemon")

--- a/functions/register.go
+++ b/functions/register.go
@@ -74,7 +74,7 @@ func Register(token string) error {
 
 func doubleCheck(host *config.Config, apiServer string) (shouldUpdate bool, err error) {
 
-	if len(config.GetServers()) == 0 { // should indicate a first join
+	if len(config.CurrServer) == 0 { // should indicate a first join
 		// do a double check of name and uuid
 		logger.Log(1, "performing first join")
 		var shouldUpdateHost bool
@@ -128,6 +128,7 @@ func handleRegisterResponse(registerResponse *models.RegisterResponse) {
 		logger.Log(0, "failed to save server", err.Error())
 	}
 	config.UpdateHost(&registerResponse.RequestedHost)
+	config.SetCurrServerCtxInFile(server.Server)
 	if err := daemon.Restart(); err != nil {
 		logger.Log(3, "daemon restart failed:", err.Error())
 	}

--- a/functions/uninstall.go
+++ b/functions/uninstall.go
@@ -69,7 +69,7 @@ func LeaveNetwork(network string, isDaemon bool) ([]error, error) {
 		if err := nc.Configure(); err != nil {
 			faults = append(faults, fmt.Errorf("failed to configure interface during node removal - %v", err.Error()))
 		} else {
-			if err = wireguard.SetPeers(); err != nil {
+			if err = wireguard.SetPeers(true); err != nil {
 				faults = append(faults, fmt.Errorf("issue setting peers after node removal - %v", err.Error()))
 			}
 			if err = routes.SetNetmakerPeerEndpointRoutes(config.Netclient().DefaultInterface); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/nftables v0.1.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/gravitl/netmaker v0.20.1-0.20230526030852-f1c32f4f7489
+	github.com/gravitl/netmaker v0.20.2-0.20230605185007-225327c15410
 	github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f
 	github.com/guumaster/hostctl v1.1.4
 	github.com/hashicorp/go-version v1.6.0
@@ -38,18 +38,24 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute v1.14.0 // indirect
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bytedance/sonic v1.8.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/coreos/go-oidc/v3 v3.6.0 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v23.0.5+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -61,6 +67,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
@@ -99,6 +106,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rqlite/gorqlite v0.0.0-20210514125552-08ff1e76b22f // indirect
 	github.com/samber/lo v1.27.1 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,24 +38,18 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute v1.14.0 // indirect
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bytedance/sonic v1.8.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
-	github.com/coreos/go-oidc/v3 v3.6.0 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v23.0.5+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -67,7 +61,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
@@ -106,7 +99,6 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rqlite/gorqlite v0.0.0-20210514125552-08ff1e76b22f // indirect
 	github.com/samber/lo v1.27.1 // indirect
-	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,12 +17,17 @@ cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHOb
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
+cloud.google.com/go v0.105.0 h1:DNtEKRBAAzeS4KyIory52wWHuClNaXJ5x1F7xa4q+5Y=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
+cloud.google.com/go/compute v1.14.0 h1:hfm2+FfxVmnRlh6LpB7cg1ZNU+5edAHmW679JePztk0=
+cloud.google.com/go/compute v1.14.0/go.mod h1:YfLtxrj9sU4Yxv+sXzZkyPjEyPBZfXHUvjxega5vAdo=
+cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -36,6 +41,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
+filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -64,6 +71,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
+github.com/coreos/go-oidc/v3 v3.6.0/go.mod h1:ZpHUsHBucTUj6WOkrP4E20UPynbLZzhTQ1XKCXkxyPc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -88,6 +97,9 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -101,6 +113,8 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
+github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
@@ -187,6 +201,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -194,6 +210,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gravitl/netmaker v0.20.1-0.20230526030852-f1c32f4f7489 h1:G4JfariYGdEIL383Uxnq3kEksLZNQUNB8AGjwsVtxaI=
 github.com/gravitl/netmaker v0.20.1-0.20230526030852-f1c32f4f7489/go.mod h1:hO0BxCLbWdzjJQU1OH8NeQvHIfaqOajB/nOxPtksDQ8=
+github.com/gravitl/netmaker v0.20.2-0.20230605185007-225327c15410 h1:yjskvp9I5AkTLFiEttPUc5UkkKbIIkuMzPCtGFjews4=
+github.com/gravitl/netmaker v0.20.2-0.20230605185007-225327c15410/go.mod h1:hO0BxCLbWdzjJQU1OH8NeQvHIfaqOajB/nOxPtksDQ8=
 github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f h1:XzsYovKdrDvj2z2HEHoeHU67+JIEFMHQKHU6oU+1fVE=
 github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f/go.mod h1:Nqo/7iOJSVP1JRSUv+FkZ0FgBjK89gjU0D/V8nH4xy8=
 github.com/guumaster/hostctl v1.1.4 h1:4zb9wEurBlz/hQiXFz9feHHfunf7oj+9serAH8ohGuM=
@@ -325,6 +343,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/samber/lo v1.27.1 h1:sTXwkRiIFIQG+G0HeAvOEnGjqWeWtI9cg5/n51KrxPg=
 github.com/samber/lo v1.27.1/go.mod h1:it33p9UtPMS7z72fP4gw/EIfQB2eI8ke7GR2wc6+Rhg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
@@ -344,6 +364,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -398,6 +419,7 @@ golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUu
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/go.sum
+++ b/go.sum
@@ -17,17 +17,12 @@ cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHOb
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
-cloud.google.com/go v0.105.0 h1:DNtEKRBAAzeS4KyIory52wWHuClNaXJ5x1F7xa4q+5Y=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
-cloud.google.com/go/compute v1.14.0 h1:hfm2+FfxVmnRlh6LpB7cg1ZNU+5edAHmW679JePztk0=
-cloud.google.com/go/compute v1.14.0/go.mod h1:YfLtxrj9sU4Yxv+sXzZkyPjEyPBZfXHUvjxega5vAdo=
-cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -41,8 +36,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
-filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -71,8 +64,6 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
-github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
-github.com/coreos/go-oidc/v3 v3.6.0/go.mod h1:ZpHUsHBucTUj6WOkrP4E20UPynbLZzhTQ1XKCXkxyPc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -97,9 +88,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -113,8 +101,6 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
-github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
@@ -201,15 +187,11 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
-github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gravitl/netmaker v0.20.1-0.20230526030852-f1c32f4f7489 h1:G4JfariYGdEIL383Uxnq3kEksLZNQUNB8AGjwsVtxaI=
-github.com/gravitl/netmaker v0.20.1-0.20230526030852-f1c32f4f7489/go.mod h1:hO0BxCLbWdzjJQU1OH8NeQvHIfaqOajB/nOxPtksDQ8=
 github.com/gravitl/netmaker v0.20.2-0.20230605185007-225327c15410 h1:yjskvp9I5AkTLFiEttPUc5UkkKbIIkuMzPCtGFjews4=
 github.com/gravitl/netmaker v0.20.2-0.20230605185007-225327c15410/go.mod h1:hO0BxCLbWdzjJQU1OH8NeQvHIfaqOajB/nOxPtksDQ8=
 github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f h1:XzsYovKdrDvj2z2HEHoeHU67+JIEFMHQKHU6oU+1fVE=
@@ -343,8 +325,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/samber/lo v1.27.1 h1:sTXwkRiIFIQG+G0HeAvOEnGjqWeWtI9cg5/n51KrxPg=
 github.com/samber/lo v1.27.1/go.mod h1:it33p9UtPMS7z72fP4gw/EIfQB2eI8ke7GR2wc6+Rhg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
-github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
@@ -364,7 +344,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -419,7 +398,6 @@ golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUu
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/gui/exported.go
+++ b/gui/exported.go
@@ -228,7 +228,7 @@ func (app *App) GoWriteToClipboard(data string) (any, error) {
 
 // App.GoPullLatestNodeConfig pulls the latest node config from the server and returns the network config
 func (app *App) GoPullLatestNodeConfig(network string) (Network, error) {
-	err := functions.Pull()
+	err := functions.Pull(true)
 	if err != nil {
 		return Network{}, err
 	}

--- a/networking/server-pong.go
+++ b/networking/server-pong.go
@@ -127,7 +127,7 @@ func storeNewPeerIface(clientPubKeyHash string, endpoint netip.Addr, latency tim
 
 func setPeerEndpoint(publicKeyHash string, value cache.EndpointCacheValue) error {
 
-	currentServerPeers := config.GetHostPeerList()
+	currentServerPeers := config.Netclient().HostPeers
 	for i := range currentServerPeers {
 		currPeer := currentServerPeers[i]
 		peerPubkeyHash := fmt.Sprintf("%v", sha1.Sum([]byte(currPeer.PublicKey.String())))

--- a/nmproxy/turn/turn.go
+++ b/nmproxy/turn/turn.go
@@ -123,6 +123,9 @@ func allocateAddr(client *turn.Client) (net.PacketConn, error) {
 // SignalPeer - signals the peer with host's turn relay endpoint
 func SignalPeer(serverName string, signal nm_models.Signal) error {
 	server := ncconfig.GetServer(serverName)
+	if server == nil {
+		return errors.New("server config not found")
+	}
 	host := ncconfig.Netclient()
 	if host == nil {
 		return fmt.Errorf("no configured host found")

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -80,7 +80,7 @@ func resetPeerRoutes() {
 }
 
 func ensureNotNodeAddr(gatewayIP net.IP) error {
-	currentPeers := config.GetHostPeerList()
+	currentPeers := config.Netclient().HostPeers
 	for i := range currentPeers {
 		peer := currentPeers[i]
 		for j := range peer.AllowedIPs {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -93,7 +93,7 @@ func ensureNotNodeAddr(gatewayIP net.IP) error {
 		}
 	}
 
-	sNodes := config.GetNodesByServer(config.CurrServer)
+	sNodes := config.GetNodes()
 	for i := range sNodes {
 		node := sNodes[i]
 		if node.Address.IP.Equal(gatewayIP) ||

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -92,16 +92,15 @@ func ensureNotNodeAddr(gatewayIP net.IP) error {
 			}
 		}
 	}
-	servers := config.GetServers()
-	for _, s := range servers {
-		sNodes := config.GetNodesByServer(s)
-		for i := range sNodes {
-			node := sNodes[i]
-			if node.Address.IP.Equal(gatewayIP) ||
-				node.Address6.IP.Equal(gatewayIP) {
-				return fmt.Errorf("assigned address found as gw")
-			}
+
+	sNodes := config.GetNodesByServer(config.CurrServer)
+	for i := range sNodes {
+		node := sNodes[i]
+		if node.Address.IP.Equal(gatewayIP) ||
+			node.Address6.IP.Equal(gatewayIP) {
+			return fmt.Errorf("assigned address found as gw")
 		}
 	}
+
 	return nil
 }

--- a/routes/routes_linux.go
+++ b/routes/routes_linux.go
@@ -92,7 +92,7 @@ func SetNetmakerPeerEndpointRoutes(defaultInterface string) error {
 		return err
 	}
 
-	currentPeers := config.GetHostPeerList()
+	currentPeers := config.Netclient().HostPeers
 	for i := range currentPeers {
 		peer := currentPeers[i]
 		if peer.Endpoint == nil {

--- a/routes/routes_unix.go
+++ b/routes/routes_unix.go
@@ -78,7 +78,7 @@ func SetNetmakerPeerEndpointRoutes(defaultInterface string) error {
 		return err
 	}
 
-	currentPeers := config.GetHostPeerList()
+	currentPeers := config.Netclient().HostPeers
 	for i := range currentPeers {
 		peer := currentPeers[i]
 		if !peer.Remove && peer.Endpoint != nil {

--- a/routes/routes_windows.go
+++ b/routes/routes_windows.go
@@ -67,7 +67,7 @@ func SetNetmakerPeerEndpointRoutes(defaultInterface string) error {
 		return err
 	}
 
-	currentPeers := config.GetHostPeerList()
+	currentPeers := config.Netclient().HostPeers
 	for i := range currentPeers {
 		peer := currentPeers[i]
 		if !peer.Remove && peer.Endpoint != nil {

--- a/wireguard/types.go
+++ b/wireguard/types.go
@@ -27,7 +27,7 @@ var wgMutex = sync.Mutex{} // used to mutex functions of the interface
 // NewNCIFace - creates a new Netclient interface in memory
 func NewNCIface(host *config.Config, nodes config.NodeMap) *NCIface {
 	firewallMark := 0
-	peers := config.GetHostPeerList()
+	peers := config.Netclient().HostPeers
 	addrs := []ifaceAddress{}
 	for _, node := range nodes {
 		if node.Address.IP != nil {

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -16,7 +16,7 @@ import (
 // SetPeers - sets peers on netmaker WireGuard interface
 func SetPeers() error {
 
-	peers := config.GetHostPeerList()
+	peers := config.Netclient().HostPeers
 	for i := range peers {
 		peer := peers[i]
 		if checkForBetterEndpoint(&peer) {

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -14,7 +14,7 @@ import (
 )
 
 // SetPeers - sets peers on netmaker WireGuard interface
-func SetPeers() error {
+func SetPeers(replace bool) error {
 
 	peers := config.Netclient().HostPeers
 	for i := range peers {
@@ -26,7 +26,7 @@ func SetPeers() error {
 	GetInterface().Config.Peers = peers
 	peers = peer.SetPeersEndpointToProxy(peers)
 	config := wgtypes.Config{
-		ReplacePeers: false,
+		ReplacePeers: replace,
 		Peers:        peers,
 	}
 	return apply(&config)


### PR DESCRIPTION
## Describe your changes

- [ ] Netclient will only talk to a single server at a time
- [ ] ability to switch between servers

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required
https://github.com/gravitl/netmaker/pull/2371
## Provide testing steps
- [ ] Perform all the critical tests from your checklist
- [ ] Test client functionality around joining/leaving networks
- [ ] Register client to multiple servers, but it should only have peers from a single single it is set to
- [ ] Switch between servers using `netclient switch [ servername ]`
- [ ] When switched between servers verify peers are reflected from the correct server, and test connections
- [ ] current server context is stored in file `.serverctx` in netclient config folder

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [x] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
