### PR TITLE
[NET-381] Reduce log level of a msg from Error to Warn

### DIFF
--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -307,7 +307,7 @@ func handleEndpointDetection(peerUpdate *models.HostPeerUpdate) {
 					peerPubKey,
 					peerInfo.ProxyListenPort,
 				); err != nil { // happens v often
-					slog.Error("failed to check for endpoint on peer", "peer", peerPubKey, "error", err)
+					slog.Warn("failed to check for endpoint on peer", "peer", peerPubKey, "error", err)
 				}
 			}
 		}

--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -307,7 +307,7 @@ func handleEndpointDetection(peerUpdate *models.HostPeerUpdate) {
 					peerPubKey,
 					peerInfo.ProxyListenPort,
 				); err != nil { // happens v often
-					slog.Warn("failed to check for endpoint on peer", "peer", peerPubKey, "error", err)
+					slog.Debug("failed to check for endpoint on peer", "peer", peerPubKey, "error", err)
 				}
 			}
 		}


### PR DESCRIPTION
## Describe your changes

I reduced log level of a msg from Error to Warn because it was appearing too frequently and it was not actually indicating a  problematic situation.

## Provide link to Netmaker PR if required

## Provide testing steps

Run netclient joining a network
Observe "failed to check for endpoint on peer" is not printed frequently.

## Checklist before requesting a review
- [X] My changes affect only 10 files or less.
- [X] I have performed a self-review of my code and tested it.
- [X] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [X] If it is a bugfix, my code is <= 200 lines.
- [X] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [X] My unit tests pass locally.
- [X] Netclient & Netmaker are awesome.
