### PR TITLE
error checks

### DIFF
--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -159,8 +159,15 @@ func startGoRoutines(wg *sync.WaitGroup) context.CancelFunc {
 
 	Pull(false)
 	nc := wireguard.NewNCIface(config.Netclient(), config.GetNodes())
-	nc.Create()
-	nc.Configure()
+	if err := nc.Create(); err != nil {
+		slog.Error("error creating netclient interface", "error", err)
+		os.Exit(1)
+	}
+	if err := nc.Configure(); err != nil {
+		slog.Error("error configuring netclient interface", "error", err)
+		nc.Close()
+		os.Exit(1)
+	}
 	wireguard.SetPeers(true)
 	server := config.GetServer(config.CurrServer)
 	if server == nil {


### PR DESCRIPTION
check for errors when daemon creates or configures wireguard interface