### PR TITLE
NET-431: Fix for multi-network Interface routes on darwin,freebsd and Egress routes fix

### DIFF
--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -147,11 +147,12 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 	isInetGW := config.UpdateHostPeers(peerUpdate.Peers)
 	_ = config.WriteNetclientConfig()
 	_ = wireguard.SetPeers(false)
-	wireguard.GetInterface().GetPeerRoutes()
+	if len(peerUpdate.EgressRoutes) > 0 {
+		wireguard.SetEgressRoutes(peerUpdate.EgressRoutes)
+	}
 	if err = routes.SetNetmakerPeerEndpointRoutes(config.Netclient().DefaultInterface); err != nil {
 		slog.Warn("error when setting peer routes after peer update", "error", err)
 	}
-	_ = wireguard.GetInterface().ApplyAddrs(true)
 	gwDelta := (currentGW4.IP != nil && !currentGW4.IP.Equal(config.GW4Addr.IP)) ||
 		(currentGW6.IP != nil && !currentGW6.IP.Equal(config.GW6Addr.IP))
 	originalGW := currentGW4

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/c-robinson/iplib v1.0.6
 	github.com/coreos/go-iptables v0.6.0
 	github.com/devilcove/httpclient v0.6.0
-	github.com/eclipse/paho.mqtt.golang v1.4.2
+	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/nftables v0.1.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/gravitl/netmaker v0.20.3-0.20230629012646-70a8d0e8578c
+	github.com/gravitl/netmaker v0.20.4-0.20230713081558-035ff71dbc17
 	github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f
 	github.com/guumaster/hostctl v1.1.4
 	github.com/hashicorp/go-version v1.6.0
@@ -40,19 +40,25 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute v1.20.1 // indirect
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/coreos/go-oidc/v3 v3.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v23.0.5+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -64,6 +70,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
@@ -103,6 +110,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rqlite/gorqlite v0.0.0-20210514125552-08ff1e76b22f // indirect
 	github.com/samber/lo v1.27.1 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -124,13 +132,13 @@ require (
 	golang.org/x/image v0.6.0 // indirect
 	golang.org/x/mobile v0.0.0-20230301163155-e0f57694e12c // indirect
 	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/oauth2 v0.9.0 // indirect
+	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,10 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
+cloud.google.com/go/compute v1.20.1 h1:6aKEtlUiwEpJzM001l0yFkpXmUVXaN8W+fbkb2AZNbg=
+cloud.google.com/go/compute v1.20.1/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
+cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -36,6 +40,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
+filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -64,6 +70,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
+github.com/coreos/go-oidc/v3 v3.6.0/go.mod h1:ZpHUsHBucTUj6WOkrP4E20UPynbLZzhTQ1XKCXkxyPc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -82,12 +90,17 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
+github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
+github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -101,6 +114,8 @@ github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SU
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
+github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
@@ -187,6 +202,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -194,6 +211,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gravitl/netmaker v0.20.3-0.20230629012646-70a8d0e8578c h1:zZIv9KVxbJ8wPZD+opuLeOEPaKZG8g60db8FjOZwyeM=
 github.com/gravitl/netmaker v0.20.3-0.20230629012646-70a8d0e8578c/go.mod h1:h/8zpORPHUNX5POfb7h2M3p30qK/PLoX1XhSPqc6xJc=
+github.com/gravitl/netmaker v0.20.4-0.20230713081558-035ff71dbc17 h1:MK7BAmZyxbvhqL0jzI4+v12EF8lS6Y61kwRAiNQ71fM=
+github.com/gravitl/netmaker v0.20.4-0.20230713081558-035ff71dbc17/go.mod h1:HzJKcxKPn5c2LD+ZAgZ4Ar3A9rSPEFHprzQWMwcUaRc=
 github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f h1:XzsYovKdrDvj2z2HEHoeHU67+JIEFMHQKHU6oU+1fVE=
 github.com/gravitl/txeh v0.0.0-20230509181318-3778c58bd69f/go.mod h1:Nqo/7iOJSVP1JRSUv+FkZ0FgBjK89gjU0D/V8nH4xy8=
 github.com/guumaster/hostctl v1.1.4 h1:4zb9wEurBlz/hQiXFz9feHHfunf7oj+9serAH8ohGuM=
@@ -326,6 +345,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/samber/lo v1.27.1 h1:sTXwkRiIFIQG+G0HeAvOEnGjqWeWtI9cg5/n51KrxPg=
 github.com/samber/lo v1.27.1/go.mod h1:it33p9UtPMS7z72fP4gw/EIfQB2eI8ke7GR2wc6+Rhg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=
@@ -345,6 +366,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -402,6 +424,7 @@ golang.org/x/arch v0.3.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -510,6 +533,8 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.9.0 h1:BPpt2kU7oMRq3kCHAA1tbSEshXRw1LpG2ztgDwrzuAs=
 golang.org/x/oauth2 v0.9.0/go.mod h1:qYgFZaFiu6Wg24azG8bdV52QJXJGbZzIIsRCdVKzbLw=
+golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -769,6 +794,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/wireguard/types.go
+++ b/wireguard/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gravitl/netclient/ncutils"
 	"github.com/gravitl/netclient/nmproxy/peer"
 	"github.com/gravitl/netmaker/logger"
-	"github.com/gravitl/netmaker/logic"
+	"github.com/gravitl/netmaker/models"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
@@ -83,8 +83,7 @@ func (n *NCIface) Configure() error {
 	wgMutex.Lock()
 	defer wgMutex.Unlock()
 	logger.Log(0, "adding addresses to netmaker interface")
-	n.GetPeerRoutes()
-	if err := n.ApplyAddrs(false); err != nil {
+	if err := n.ApplyAddrs(); err != nil {
 		return err
 	}
 	if err := n.SetMTU(); err != nil {
@@ -93,38 +92,18 @@ func (n *NCIface) Configure() error {
 	return apply(&n.Config)
 }
 
-// NCIface.GetPeerRoutes - fetches additional routes that are needed to be added to the interface
-func (nc *NCIface) GetPeerRoutes() {
-	var routes []ifaceAddress
-	if len(nc.Addresses) == 0 {
-		return
-	}
-	routeMap := make(map[string]struct{})
-	for _, peer := range nc.Config.Peers {
-		for _, allowedIP := range peer.AllowedIPs {
-			addRoute := true
-			for _, address := range nc.Addresses {
-				normCIDR, err := logic.NormalizeCIDR(address.Network.String())
-				if err == nil {
-					if logic.IsAddressInCIDR(allowedIP.IP, normCIDR) {
-						addRoute = false
-					}
-				}
-			}
-			if addRoute {
-				// add route to the interface
-				if _, ok := routeMap[allowedIP.String()]; !ok {
-					routeMap[allowedIP.String()] = struct{}{}
-					routes = append(routes, ifaceAddress{
-						IP:       peer.AllowedIPs[0].IP,
-						Network:  allowedIP,
-						AddRoute: true,
-					})
-				}
-			}
+func SetEgressRoutes(egressRoutes []models.EgressNetworkRoutes) {
+	addrs := []ifaceAddress{}
+	for _, egressRoute := range egressRoutes {
+		for _, egressRange := range egressRoute.EgressRanges {
+			addrs = append(addrs, ifaceAddress{
+				IP:      egressRoute.NodeAddr.IP,
+				Network: config.ToIPNet(egressRange),
+			})
 		}
+
 	}
-	nc.Addresses = append(nc.Addresses, routes...)
+	SetRoutes(addrs)
 }
 
 func GetInterface() *NCIface {

--- a/wireguard/types.go
+++ b/wireguard/types.go
@@ -116,12 +116,11 @@ func (nc *NCIface) GetPeerRoutes() {
 				if _, ok := routeMap[allowedIP.String()]; !ok {
 					routeMap[allowedIP.String()] = struct{}{}
 					routes = append(routes, ifaceAddress{
-						IP:       allowedIP.IP,
+						IP:       peer.AllowedIPs[0].IP,
 						Network:  allowedIP,
 						AddRoute: true,
 					})
 				}
-
 			}
 		}
 	}

--- a/wireguard/wireguard_darwin.go
+++ b/wireguard/wireguard_darwin.go
@@ -21,16 +21,16 @@ func (nc *NCIface) ApplyAddrs(addOnlyRoutes bool) error {
 		if !addOnlyRoutes && !address.AddRoute && address.IP != nil {
 			if address.IP.To4() != nil {
 
-				cmd := exec.Command("ifconfig", nc.Name, "inet", "alias", address.IP.String(), address.IP.String())
+				cmd := exec.Command("ifconfig", nc.Name, "inet", "add", address.IP.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
-					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), out))
+					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), string(out)))
 					continue
 				}
 			} else {
 
-				cmd := exec.Command("ifconfig", nc.Name, "inet6", "alias", address.IP.String(), address.IP.String())
+				cmd := exec.Command("ifconfig", nc.Name, "inet6", "add", address.IP.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
-					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), out))
+					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), string(out)))
 					continue
 				}
 			}
@@ -40,13 +40,13 @@ func (nc *NCIface) ApplyAddrs(addOnlyRoutes bool) error {
 			address.Network.String() != "0.0.0.0/0" &&
 			address.Network.String() != "::/0" {
 			if address.Network.IP.To4() != nil {
-				cmd := exec.Command("route", "add", "-net", "-inet", address.Network.String(), "-interface", nc.Name)
+				cmd := exec.Command("route", "add", "-net", "-inet", address.Network.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
-					logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), out))
+					logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), string(out)))
 					continue
 				}
 			} else {
-				cmd := exec.Command("route", "add", "-net", "-inet6", address.Network.String(), "-interface", nc.Name)
+				cmd := exec.Command("route", "add", "-net", "-inet6", address.Network.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
 					logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), out))
 					continue

--- a/wireguard/wireguard_darwin.go
+++ b/wireguard/wireguard_darwin.go
@@ -55,6 +55,7 @@ func (nc *NCIface) ApplyAddrs() error {
 	return nil
 }
 
+// SetRoutes - sets additional routes to the interface
 func SetRoutes(addrs []ifaceAddress) {
 	for _, addr := range addrs {
 		if addr.IP == nil || addr.Network.IP == nil || addr.Network.String() == "0.0.0.0/0" ||

--- a/wireguard/wireguard_darwin.go
+++ b/wireguard/wireguard_darwin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gravitl/netclient/ncutils"
 	"github.com/gravitl/netmaker/logger"
+	"golang.org/x/exp/slog"
 )
 
 // NCIface.Create - makes a new Wireguard interface for darwin users (userspace)
@@ -66,13 +67,13 @@ func SetRoutes(addrs []ifaceAddress) {
 		if addr.Network.IP.To4() != nil {
 			cmd := exec.Command("route", "add", "-net", "-inet", addr.Network.String(), addr.IP.String())
 			if out, err := cmd.CombinedOutput(); err != nil {
-				logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), string(out)))
+				slog.Error("failed to add route with", "command", cmd.String(), "error", string(out))
 				continue
 			}
 		} else {
 			cmd := exec.Command("route", "add", "-net", "-inet6", addr.Network.String(), addr.IP.String())
 			if out, err := cmd.CombinedOutput(); err != nil {
-				logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), out))
+				slog.Error("failed to add route with", "command", cmd.String(), "error", string(out))
 				continue
 			}
 		}

--- a/wireguard/wireguard_darwin.go
+++ b/wireguard/wireguard_darwin.go
@@ -24,14 +24,14 @@ func (nc *NCIface) ApplyAddrs() error {
 
 				cmd := exec.Command("ifconfig", nc.Name, "inet", "add", address.IP.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
-					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), string(out)))
+					slog.Error("error adding address", "command", cmd.String(), "error", string(out))
 					continue
 				}
 			} else {
 
 				cmd := exec.Command("ifconfig", nc.Name, "inet6", "add", address.IP.String(), address.IP.String())
 				if out, err := cmd.CombinedOutput(); err != nil {
-					logger.Log(0, fmt.Sprintf("adding address command \"%v\" failed with output %s and error: ", cmd.String(), string(out)))
+					slog.Error("error adding address", "command", cmd.String(), "error", string(out))
 					continue
 				}
 			}
@@ -40,13 +40,13 @@ func (nc *NCIface) ApplyAddrs() error {
 		if address.Network.IP.To4() != nil {
 			cmd := exec.Command("route", "add", "-net", "-inet", address.Network.String(), address.IP.String())
 			if out, err := cmd.CombinedOutput(); err != nil {
-				logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), string(out)))
+				slog.Error("failed to add route", "command", cmd.String(), "error", string(out))
 				continue
 			}
 		} else {
 			cmd := exec.Command("route", "add", "-net", "-inet6", address.Network.String(), address.IP.String())
 			if out, err := cmd.CombinedOutput(); err != nil {
-				logger.Log(0, fmt.Sprintf("failed to add route with command %s - %v", cmd.String(), out))
+				slog.Error("failed to add route", "command", cmd.String(), "error", string(out))
 				continue
 			}
 		}

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -93,11 +93,11 @@ func SetRoutes(addrs []ifaceAddress) {
 			addr.Network.String() != "::/0" {
 			if addr.IP.To4() != nil {
 				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", addr.Network.String(), addr.IP.String()), true); err != nil {
-					logger.Log(1, "error adding address to interface ", addr.Network.String(), err.Error())
+					slog.Error("error adding address to interface", addr.Network.String(), "error", err.Error())
 				}
 			} else {
 				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", addr.Network.String(), addr.IP.String()), true); err != nil {
-					logger.Log(1, "error adding address to interface ", addr.Network.String(), err.Error())
+					slog.Error("error adding address to interface ", addr.Network.String(), "error", err.Error())
 				}
 			}
 

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -82,6 +82,7 @@ func (nc *NCIface) ApplyAddrs() error {
 	return nil
 }
 
+// SetRoutes - sets additional routes to the interface
 func SetRoutes(addrs []ifaceAddress) {
 	for _, addr := range addrs {
 		if addr.IP == nil || addr.Network.IP == nil || addr.Network.String() == "0.0.0.0/0" ||

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -61,24 +61,23 @@ func (nc *NCIface) ApplyAddrs() error {
 	for _, address := range nc.Addresses {
 		if address.IP.To4() != nil {
 			if _, err := ncutils.RunCmd(ifconfig+" "+nc.Name+" inet "+address.IP.String()+" alias", true); err != nil {
-				logger.Log(1, "error adding address to interface: ", address.IP.String(), err.Error())
+				slog.Error("error adding address to interface", "address", address.IP.String(), "error", err.Error())
 			}
 		} else {
 			if _, err := ncutils.RunCmd(ifconfig+" "+nc.Name+" inet6 "+address.IP.String()+" alias", true); err != nil {
-				logger.Log(1, "error adding address to interface: ", address.IP.String(), err.Error())
+				slog.Error("error adding address to interface", "address", address.IP.String(), "error", err.Error())
 			}
 		}
 
 		if address.IP.To4() != nil {
 			if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", address.Network.String(), address.IP.String()), true); err != nil {
-				logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
+				slog.Error("error adding address to interface", "address", address.Network.String(), "error", err.Error())
 			}
 		} else {
 			if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", address.Network.String(), address.IP.String()), true); err != nil {
-				logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
+				slog.Error("error adding address to interface ", "address", address.Network.String(), "error", err.Error())
 			}
 		}
-
 	}
 	return nil
 }

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -74,11 +74,11 @@ func (nc *NCIface) ApplyAddrs(addOnlyRoutes bool) error {
 			address.Network.String() != "0.0.0.0/0" &&
 			address.Network.String() != "::/0" {
 			if address.IP.To4() != nil {
-				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s -interface %s", address.Network.String(), nc.Name), true); err != nil {
+				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", address.Network.String(), address.IP.String()), true); err != nil {
 					logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
 				}
 			} else {
-				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s -interface %s", address.Network.String(), nc.Name), true); err != nil {
+				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", address.Network.String(), address.IP.String()), true); err != nil {
 					logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
 				}
 			}

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -51,41 +51,57 @@ func (nc *NCIface) Close() {
 }
 
 // NCIface.ApplyAddrs - applies the assigned node addresses to given interface (netLink)
-func (nc *NCIface) ApplyAddrs(addOnlyRoutes bool) error {
+func (nc *NCIface) ApplyAddrs() error {
 	ifconfig, err := exec.LookPath("ifconfig")
 	if err != nil {
 		logger.Log(0, "failed to locate ifconfig", err.Error())
 		return fmt.Errorf("failed to locate ifconfig %w", err)
 	}
 	for _, address := range nc.Addresses {
-		if !addOnlyRoutes && !address.AddRoute {
-			if address.IP.To4() != nil {
-				if _, err := ncutils.RunCmd(ifconfig+" "+nc.Name+" inet "+address.IP.String()+" alias", true); err != nil {
-					logger.Log(1, "error adding address to interface: ", address.IP.String(), err.Error())
-				}
-			} else {
-				if _, err := ncutils.RunCmd(ifconfig+" "+nc.Name+" inet6 "+address.IP.String()+" alias", true); err != nil {
-					logger.Log(1, "error adding address to interface: ", address.IP.String(), err.Error())
-				}
+		if address.IP.To4() != nil {
+			if _, err := ncutils.RunCmd(ifconfig+" "+nc.Name+" inet "+address.IP.String()+" alias", true); err != nil {
+				logger.Log(1, "error adding address to interface: ", address.IP.String(), err.Error())
+			}
+		} else {
+			if _, err := ncutils.RunCmd(ifconfig+" "+nc.Name+" inet6 "+address.IP.String()+" alias", true); err != nil {
+				logger.Log(1, "error adding address to interface: ", address.IP.String(), err.Error())
 			}
 		}
 
-		if address.AddRoute &&
-			address.Network.String() != "0.0.0.0/0" &&
-			address.Network.String() != "::/0" {
-			if address.IP.To4() != nil {
-				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", address.Network.String(), address.IP.String()), true); err != nil {
-					logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
+		if address.IP.To4() != nil {
+			if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", address.Network.String(), address.IP.String()), true); err != nil {
+				logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
+			}
+		} else {
+			if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", address.Network.String(), address.IP.String()), true); err != nil {
+				logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
+			}
+		}
+
+	}
+	return nil
+}
+
+func SetRoutes(addrs []ifaceAddress) {
+	for _, addr := range addrs {
+		if addr.IP == nil || addr.Network.IP == nil || addr.Network.String() == "0.0.0.0/0" ||
+			addr.Network.String() == "::/0" {
+			continue
+		}
+		if addr.Network.String() != "0.0.0.0/0" &&
+			addr.Network.String() != "::/0" {
+			if addr.IP.To4() != nil {
+				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", addr.Network.String(), addr.IP.String()), true); err != nil {
+					logger.Log(1, "error adding address to interface ", addr.Network.String(), err.Error())
 				}
 			} else {
-				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", address.Network.String(), address.IP.String()), true); err != nil {
-					logger.Log(1, "error adding address to interface ", address.Network.String(), err.Error())
+				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", addr.Network.String(), addr.IP.String()), true); err != nil {
+					logger.Log(1, "error adding address to interface ", addr.Network.String(), err.Error())
 				}
 			}
 
 		}
 	}
-	return nil
 }
 
 // NCIface.SetMTU - set MTU for netmaker interface

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -94,11 +94,11 @@ func SetRoutes(addrs []ifaceAddress) {
 			addr.Network.String() != "::/0" {
 			if addr.IP.To4() != nil {
 				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet %s %s", addr.Network.String(), addr.IP.String()), true); err != nil {
-					slog.Error("error adding address to interface", addr.Network.String(), "error", err.Error())
+					slog.Error("error adding address to interface", "address", addr.Network.String(), "error", err.Error())
 				}
 			} else {
 				if _, err := ncutils.RunCmd(fmt.Sprintf("route add -net -inet6 %s %s", addr.Network.String(), addr.IP.String()), true); err != nil {
-					slog.Error("error adding address to interface ", addr.Network.String(), "error", err.Error())
+					slog.Error("error adding address to interface ", "address", addr.Network.String(), "error", err.Error())
 				}
 			}
 

--- a/wireguard/wireguard_freebsd.go
+++ b/wireguard/wireguard_freebsd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gravitl/netclient/ncutils"
 	"github.com/gravitl/netmaker/logger"
+	"golang.org/x/exp/slog"
 )
 
 const kernelModule = "/boot/modules/if_wg.ko"

--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -143,7 +143,7 @@ func SetRoutes(addrs []ifaceAddress) {
 			Gw:        addr.IP,
 			Dst:       &addr.Network,
 		}); err != nil {
-			logger.Log(1, "error adding route", err.Error())
+			slog.Error("error adding route", "error", err.Error())
 		}
 
 	}

--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -125,6 +125,7 @@ func (nc *NCIface) ApplyAddrs() error {
 	return nil
 }
 
+// SetRoutes - sets additional routes to the interface
 func SetRoutes(addrs []ifaceAddress) {
 	l, err := netlink.LinkByName(ncutils.GetInterfaceName())
 	if err != nil {

--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -137,7 +137,7 @@ func SetRoutes(addrs []ifaceAddress) {
 			addr.Network.String() == "::/0" {
 			continue
 		}
-		logger.Log(3, "adding route", addr.IP.String(), addr.Network.String(), "to netmaker interface")
+		slog.Info("adding route", fmt.Sprintf("%s -> %s", addr.IP.String(), addr.Network.String()))
 		if err := netlink.RouteAdd(&netlink.Route{
 			LinkIndex: l.Attrs().Index,
 			Gw:        addr.IP,

--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -114,16 +114,17 @@ func (nc *NCIface) ApplyAddrs(addOnlyRoutes bool) error {
 
 	for _, addr := range nc.Addresses {
 		if !addOnlyRoutes && !addr.AddRoute && addr.IP != nil {
-			logger.Log(3, "adding address", addr.IP.String(), "to netmaker interface")
+			logger.Log(3, "adding address", addr.IP.String(), addr.Network.String(), "to netmaker interface")
 			if err := netlink.AddrAdd(l, &netlink.Addr{IPNet: &net.IPNet{IP: addr.IP, Mask: addr.Network.Mask}}); err != nil {
 				logger.Log(1, "error adding addr", err.Error())
 
 			}
 		}
 		if addr.AddRoute && addr.Network.String() != "0.0.0.0/0" && addr.Network.String() != "::/0" {
-			logger.Log(3, "adding route", addr.IP.String(), "to netmaker interface")
+			logger.Log(3, "adding route", addr.IP.String(), addr.Network.String(), "to netmaker interface")
 			if err := netlink.RouteAdd(&netlink.Route{
 				LinkIndex: l.Attrs().Index,
+				Gw:        addr.IP,
 				Dst:       &addr.Network,
 			}); err != nil {
 				logger.Log(1, "error adding route", err.Error())

--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -137,7 +137,7 @@ func SetRoutes(addrs []ifaceAddress) {
 			addr.Network.String() == "::/0" {
 			continue
 		}
-		slog.Info("adding route", fmt.Sprintf("%s -> %s", addr.IP.String(), addr.Network.String()))
+		slog.Info("adding route to interface", "route", fmt.Sprintf("%s -> %s", addr.IP.String(), addr.Network.String()))
 		if err := netlink.RouteAdd(&netlink.Route{
 			LinkIndex: l.Attrs().Index,
 			Gw:        addr.IP,

--- a/wireguard/wireguard_linux.go
+++ b/wireguard/wireguard_linux.go
@@ -114,9 +114,9 @@ func (nc *NCIface) ApplyAddrs() error {
 
 	for _, addr := range nc.Addresses {
 		if addr.IP != nil && addr.Network.IP != nil {
-			logger.Log(3, "adding address", addr.IP.String(), addr.Network.String(), "to netmaker interface")
+			slog.Info("adding address", "address", addr.IP.String(), "network", addr.Network.String())
 			if err := netlink.AddrAdd(l, &netlink.Addr{IPNet: &net.IPNet{IP: addr.IP, Mask: addr.Network.Mask}}); err != nil {
-				logger.Log(1, "error adding addr", err.Error())
+				slog.Error("error adding addr", "error", err.Error())
 
 			}
 		}

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -56,6 +56,7 @@ func (nc *NCIface) ApplyAddrs() error {
 	return adapter.(*driver.Adapter).LUID().SetIPAddresses(prefixAddrs)
 }
 
+// SetRoutes - sets additional routes to the interface
 func SetRoutes(addrs []ifaceAddress) {
 	for _, addr := range addrs {
 		if addr.IP == nil || addr.Network.IP == nil || addr.Network.String() == "0.0.0.0/0" ||

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -65,13 +65,13 @@ func SetRoutes(addrs []ifaceAddress) {
 			continue
 		}
 		mask := net.IP(addr.Network.Mask)
-		slog.Info("adding route", fmt.Sprintf("%s -> %s", addr.IP.String(), addr.Network.String()))
+		slog.Info("adding route to interface", "route", fmt.Sprintf("%s -> %s", addr.IP.String(), addr.Network.String()))
 		cmd := fmt.Sprintf("route -p add %s MASK %v %s", addr.IP.String(),
 			mask,
 			addr.IP.String())
 		_, err := ncutils.RunCmd(cmd, false)
 		if err != nil {
-			logger.Log(0, "failed to apply egress range", addr.IP.String())
+			slog.Error("failed to apply", "egress range", addr.IP.String())
 		}
 	}
 }

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gravitl/netclient/ncutils"
 	"github.com/gravitl/netmaker/logger"
+	"golang.org/x/exp/slog"
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/windows/driver"
 )

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -64,7 +64,7 @@ func SetRoutes(addrs []ifaceAddress) {
 			continue
 		}
 		mask := net.IP(addr.Network.Mask)
-		logger.Log(3, "adding route", addr.IP.String(), addr.Network.String(), "to netmaker interface")
+		slog.Info("adding route", fmt.Sprintf("%s -> %s", addr.IP.String(), addr.Network.String()))
 		cmd := fmt.Sprintf("route -p add %s MASK %v %s", addr.IP.String(),
 			mask,
 			addr.IP.String())

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -29,10 +29,10 @@ func (nc *NCIface) Create() error {
 			return err
 		}
 	} else {
-		logger.Log(0, "re-using existing adapter")
+		slog.Info("re-using existing adapter")
 	}
 
-	logger.Log(3, "created Windows tunnel")
+	slog.Info("created Windows tunnel")
 	nc.Iface = adapter
 	return adapter.SetAdapterState(driver.AdapterStateUp)
 }
@@ -49,9 +49,8 @@ func (nc *NCIface) ApplyAddrs() error {
 		if err == nil {
 			prefixAddrs = append(prefixAddrs, addr)
 		} else {
-			logger.Log(0, fmt.Sprintf("failed to append ip to Netclient adapter %v", err))
+			slog.Error("failed to append ip to Netclient adapter", "error", err)
 		}
-
 	}
 
 	return adapter.(*driver.Adapter).LUID().SetIPAddresses(prefixAddrs)

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -44,7 +44,7 @@ func (nc *NCIface) ApplyAddrs() error {
 	for i := range nc.Addresses {
 
 		maskSize, _ := nc.Addresses[i].Network.Mask.Size()
-		logger.Log(1, "appending address", fmt.Sprintf("%s/%d to nm interface", nc.Addresses[i].IP.String(), maskSize))
+		slog.Info("appending address", "address", fmt.Sprintf("%s/%d to nm interface", nc.Addresses[i].IP.String(), maskSize))
 		addr, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", nc.Addresses[i].IP.String(), maskSize))
 		if err == nil {
 			prefixAddrs = append(prefixAddrs, addr)

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -62,7 +62,6 @@ func SetRoutes(addrs []ifaceAddress) {
 			addr.Network.String() == "::/0" {
 			continue
 		}
-		maskSize, _ := addr.Network.Mask.Size()
 		mask := net.IP(addr.Network.Mask)
 		logger.Log(3, "adding route", addr.IP.String(), addr.Network.String(), "to netmaker interface")
 		cmd := fmt.Sprintf("route -p add %s MASK %v %s", addr.IP.String(),

--- a/wireguard/wireguard_windows.go
+++ b/wireguard/wireguard_windows.go
@@ -37,49 +37,42 @@ func (nc *NCIface) Create() error {
 }
 
 // NCIface.ApplyAddrs - applies addresses to windows tunnel ifaces, unused currently
-func (nc *NCIface) ApplyAddrs(addOnlyRoutes bool) error {
+func (nc *NCIface) ApplyAddrs() error {
 	adapter := nc.Iface
 	prefixAddrs := []netip.Prefix{}
-	egressRanges := []ifaceAddress{}
-	var egressRoute *ifaceAddress
 	for i := range nc.Addresses {
-		if !nc.Addresses[i].AddRoute {
-			maskSize, _ := nc.Addresses[i].Network.Mask.Size()
-			logger.Log(1, "appending address", fmt.Sprintf("%s/%d to nm interface", nc.Addresses[i].IP.String(), maskSize))
-			addr, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", nc.Addresses[i].IP.String(), maskSize))
-			if err == nil {
-				prefixAddrs = append(prefixAddrs, addr)
-			} else {
-				logger.Log(0, fmt.Sprintf("failed to append ip to Netclient adapter %v", err))
-			}
-			if egressRoute == nil {
-				egressRoute = &nc.Addresses[i]
-			}
-		} else {
-			egressRanges = append(egressRanges, nc.Addresses[i])
-		}
-	}
 
-	if egressRoute != nil && len(egressRanges) > 0 {
-		for i := range egressRanges {
-			if egressRanges[i].Network.String() == "0.0.0.0/0" ||
-				egressRanges[i].Network.String() == "::/0" {
-				continue
-			}
-			maskSize, _ := egressRanges[i].Network.Mask.Size()
-			mask := net.IP(egressRanges[i].Network.Mask)
-			logger.Log(1, "appending egress range", fmt.Sprintf("%s/%d to nm interface", egressRanges[i].IP.String(), maskSize))
-			cmd := fmt.Sprintf("route -p add %s MASK %v %s", egressRanges[i].IP.String(),
-				mask,
-				egressRoute.IP.String())
-			_, err := ncutils.RunCmd(cmd, false)
-			if err != nil {
-				logger.Log(0, "failed to apply egress range", egressRanges[i].IP.String())
-			}
+		maskSize, _ := nc.Addresses[i].Network.Mask.Size()
+		logger.Log(1, "appending address", fmt.Sprintf("%s/%d to nm interface", nc.Addresses[i].IP.String(), maskSize))
+		addr, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", nc.Addresses[i].IP.String(), maskSize))
+		if err == nil {
+			prefixAddrs = append(prefixAddrs, addr)
+		} else {
+			logger.Log(0, fmt.Sprintf("failed to append ip to Netclient adapter %v", err))
 		}
+
 	}
 
 	return adapter.(*driver.Adapter).LUID().SetIPAddresses(prefixAddrs)
+}
+
+func SetRoutes(addrs []ifaceAddress) {
+	for _, addr := range addrs {
+		if addr.IP == nil || addr.Network.IP == nil || addr.Network.String() == "0.0.0.0/0" ||
+			addr.Network.String() == "::/0" {
+			continue
+		}
+		maskSize, _ := addr.Network.Mask.Size()
+		mask := net.IP(addr.Network.Mask)
+		logger.Log(3, "adding route", addr.IP.String(), addr.Network.String(), "to netmaker interface")
+		cmd := fmt.Sprintf("route -p add %s MASK %v %s", addr.IP.String(),
+			mask,
+			addr.IP.String())
+		_, err := ncutils.RunCmd(cmd, false)
+		if err != nil {
+			logger.Log(0, "failed to apply egress range", addr.IP.String())
+		}
+	}
 }
 
 // NCIface.Close - closes the managed WireGuard interface


### PR DESCRIPTION
## Describe your changes

- On darwin,freebsd Set Routes via Gw to work on multiple networks correctly
- set additional routes via different func
- set egress routes on peer update

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required
https://github.com/gravitl/netmaker/pull/2452
## Provide testing steps

- [ ] Need to test these changes on all four supported OS
- [ ] Join nodes on multiple networks, and check whether nodes are reachable on both the networks
- [ ] create egress gateways on multiple networks and check whether those ranges are reachable

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
