### PR TITLE
Net 444

### DIFF
--- a/daemon/common_freebsd.go
+++ b/daemon/common_freebsd.go
@@ -91,21 +91,14 @@ run_rc_command "$1"
 netclient_args="daemon"`
 
 	rcbytes := []byte(rcFile)
-	if !ncutils.FileExists("/etc/rc.d/netclient") {
-		err := os.WriteFile("/etc/rc.d/netclient", rcbytes, 0744)
-		if err != nil {
-			return err
-		}
-		rcConfigbytes := []byte(rcConfig)
-		if !ncutils.FileExists("/etc/rc.conf.d/netclient") {
-			err := os.WriteFile("/etc/rc.conf.d/netclient", rcConfigbytes, 0644)
-			if err != nil {
-				return err
-			}
-			start()
-			return nil
-		}
+	if err := os.WriteFile("/etc/rc.d/netclient", rcbytes, 0755); err != nil {
+		return err
 	}
+	rcConfigbytes := []byte(rcConfig)
+	if err := os.WriteFile("/etc/rc.conf.d/netclient", rcConfigbytes, 0644); err != nil {
+		return err
+	}
+	start()
 	return nil
 }
 

--- a/daemon/common_freebsd.go
+++ b/daemon/common_freebsd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gravitl/netclient/config"
 	"github.com/gravitl/netclient/ncutils"
 	"github.com/gravitl/netmaker/logger"
+	"golang.org/x/exp/slog"
 )
 
 const ExecDir = "/sbin/"
@@ -90,6 +91,7 @@ run_rc_command "$1"
 	rcConfig := `netclient="YES"
 netclient_args="daemon"`
 
+	slog.Info("Installing netclient service files")
 	rcbytes := []byte(rcFile)
 	if err := os.WriteFile("/etc/rc.d/netclient", rcbytes, 0755); err != nil {
 		return err
@@ -98,6 +100,7 @@ netclient_args="daemon"`
 	if err := os.WriteFile("/etc/rc.conf.d/netclient", rcConfigbytes, 0644); err != nil {
 		return err
 	}
+	slog.Info("starting deamon")
 	start()
 	return nil
 }

--- a/daemon/common_freebsd.go
+++ b/daemon/common_freebsd.go
@@ -115,7 +115,7 @@ func stop() error {
 
 // service- accepts args to service netclient and applies
 func service(command string) error {
-	if _, err := ncutils.RunCmdFormatted("service netclient "+command, true); err != nil {
+	if _, err := ncutils.RunCmd("service netclient "+command, true); err != nil {
 		return err
 	}
 	return nil

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gravitl/netmaker/logger"
 	"golang.org/x/exp/slog"
 )
 
@@ -45,8 +44,7 @@ func RunCmd(command string, printerr bool) (string, error) {
 	}()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
-		logger.Log(0, "error running command:", command)
-		logger.Log(0, strings.TrimSuffix(string(out), "\n"))
+		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())
 	}
 	return string(out), err
 }

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"runtime/debug"
 	"strings"
-	"syscall"
 	"time"
 
 	"golang.org/x/exp/slog"
@@ -36,12 +35,12 @@ func RunCmd(command string, printerr bool) (string, error) {
 	args := strings.Fields(command)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	go func() {
-		<-ctx.Done()
-		_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
-	}()
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	//cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	//go func() {
+	//<-ctx.Done()
+	//_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
+	//}()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
 		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -1,12 +1,10 @@
 package ncutils
 
 import (
-	"context"
 	"os/exec"
 	"runtime/debug"
 	"strings"
 	"syscall"
-	"time"
 
 	"golang.org/x/exp/slog"
 )
@@ -34,14 +32,14 @@ func GetEmbedded() error {
 // Runs Commands for FreeBSD
 func RunCmd(command string, printerr bool) (string, error) {
 	args := strings.Fields(command)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	//ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	//defer cancel()
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	go func() {
-		<-ctx.Done()
-		_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
-	}()
+	//go func() {
+	//<-ctx.Done()
+	//_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
+	//}()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
 		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gravitl/netmaker/logger"
+	"golang.org/x/exp/slog"
 )
 
 // RunCmdFormatted - run a command formatted for freebsd
@@ -19,8 +20,7 @@ func RunCmdFormatted(command string, printerr bool) (string, error) {
 	cmd.Wait()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
-		logger.Log(0, "error running command: ", command)
-		logger.Log(0, strings.TrimSuffix(string(out), "\n"))
+		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())
 	}
 	return string(out), err
 }

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -40,7 +40,7 @@ func RunCmd(command string, printerr bool) (string, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	go func() {
 		<-ctx.Done()
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
 	}()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -1,10 +1,12 @@
 package ncutils
 
 import (
+	"context"
 	"os/exec"
 	"runtime/debug"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/exp/slog"
 )
@@ -32,16 +34,14 @@ func GetEmbedded() error {
 // Runs Commands for FreeBSD
 func RunCmd(command string, printerr bool) (string, error) {
 	args := strings.Fields(command)
-	//ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	//defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	//go func() {
-	//<-ctx.Done()
-	//_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
-	//}()
-	cmd.Start()
-	cmd.Wait()
+	go func() {
+		<-ctx.Done()
+		_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
+	}()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
 		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -3,6 +3,7 @@ package ncutils
 import (
 	"context"
 	"os/exec"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -13,6 +14,7 @@ import (
 
 // RunCmdFormatted - run a command formatted for freebsd
 func RunCmdFormatted(command string, printerr bool) (string, error) {
+	debug.PrintStack()
 
 	args := strings.Fields(command)
 	cmd := exec.Command(args[0], args[1:]...)

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -40,6 +40,8 @@ func RunCmd(command string, printerr bool) (string, error) {
 	//<-ctx.Done()
 	//_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
 	//}()
+	cmd.Start()
+	cmd.Wait()
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
 		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())

--- a/ncutils/netclientutils_freebsd.go
+++ b/ncutils/netclientutils_freebsd.go
@@ -41,6 +41,10 @@ func RunCmd(command string, printerr bool) (string, error) {
 	//<-ctx.Done()
 	//_ = syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
 	//}()
+	if err := cmd.Run(); err != nil {
+		slog.Warn("error running command with CmdRun: ", "command", command, "error", err)
+	}
+
 	out, err := cmd.CombinedOutput()
 	if err != nil && printerr {
 		slog.Warn("error running command: ", "command", command, "output", strings.TrimSuffix(string(out), "\n"), "error", err.Error())


### PR DESCRIPTION
update permissions of service file
refactor start/stop of netclient service
* error messages from freebsd runCmd are not consistent; using netclient service status to determine if start/stop worked correctly