### PR TITLE
NET-464

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -21,7 +21,7 @@ For example:
 netclient connect my-network-name`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			fmt.Println("\nPlease specify the network name as the first argument. For example: netclient connect my-network-name")
+			fmt.Println("\nPlease specify the network name as the argument. For example: netclient connect my-network-name")
 			nodes := config.GetNodes()
 			if len(nodes) > 0 {
 				fmt.Println("\nAvailable Networks:")

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/gravitl/netclient/config"
 	"github.com/gravitl/netclient/functions"
 	"github.com/spf13/cobra"
 )
@@ -13,17 +14,30 @@ import (
 // connectCmd represents the connect command
 var connectCmd = &cobra.Command{
 	Use:   "connect",
-	Args:  cobra.ExactArgs(1),
 	Short: "connect to a netmaker network",
 	Long: `connect to specified network
 For example:
 
-netclient connect my-network`,
+netclient connect my-network-name`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := functions.Connect(args[0]); err != nil {
-			fmt.Println("\nconnect failed:", err)
+		if len(args) < 1 {
+			fmt.Println("\nPlease specify the network name as the first argument. For example: netclient connect my-network-name")
+			nodes := config.GetNodes()
+			if len(nodes) > 0 {
+				fmt.Println("\nAvailable Networks:")
+				for _, node := range nodes {
+					fmt.Println(node.Network)
+				}
+			} else {
+				fmt.Println("\nNo Networks Available")
+			}
 		} else {
-			fmt.Println("\nnode is connected to", args[0])
+			fmt.Println("connect called", args)
+			if err := functions.Connect(args[0]); err != nil {
+				fmt.Println("\nconnect failed:", err)
+			} else {
+				fmt.Println("\nnode is connected to", args[0])
+			}
 		}
 	},
 }

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -21,7 +21,7 @@ For example:
 netclient disconnect my-network-name`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			fmt.Println("\nPlease specify the network name as the first argument. For example: netclient disconnect my-network-name")
+			fmt.Println("\nPlease specify the network name as the argument. For example: netclient disconnect my-network-name")
 			nodes := config.GetNodes()
 			if len(nodes) > 0 {
 				fmt.Println("\nAvailable Networks:")

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/gravitl/netclient/config"
 	"github.com/gravitl/netclient/functions"
 	"github.com/spf13/cobra"
 )
@@ -13,18 +14,30 @@ import (
 // disconnectCmd represents the disconnect command
 var disconnectCmd = &cobra.Command{
 	Use:   "disconnect",
-	Args:  cobra.ExactArgs(1),
 	Short: "disconnet from a network",
 	Long: `disconnect from the specified network
 For example:
 
-netclient disconnect my-network`,
+netclient disconnect my-network-name`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("disconnect called", args)
-		if err := functions.Disconnect(args[0]); err != nil {
-			fmt.Println("\nnode disconnect failed: ", err)
+		if len(args) < 1 {
+			fmt.Println("\nPlease specify the network name as the first argument. For example: netclient disconnect my-network-name")
+			nodes := config.GetNodes()
+			if len(nodes) > 0 {
+				fmt.Println("\nAvailable Networks:")
+				for _, node := range nodes {
+					fmt.Println(node.Network)
+				}
+			} else {
+				fmt.Println("\nNo Networks Available")
+			}
 		} else {
-			fmt.Println("\nnode is disconnected from", args[0])
+			fmt.Println("disconnect called", args)
+			if err := functions.Disconnect(args[0]); err != nil {
+				fmt.Println("\nnode disconnect failed: ", err)
+			} else {
+				fmt.Println("\nnode is disconnected from", args[0])
+			}
 		}
 	},
 }


### PR DESCRIPTION
* On both connect and disconnect cli commands, notifying the user about specifying the network name.

* On both connect and disconnect cli commands, listing out the network names that the netclient have access to.

* Also showing no networks available message if the netclient do not have access to any networks.

## Describe your changes
Added network list upon executing the connect and disconnect cli commands without any arguments.

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps
1. Connect netclient to one or more networks.
2. Use command -> "netclient connect" or "netclient disconnect" without any arguments.
3. This should provide a more helpful message and list out the networks netclient have access to.
4. Remove the host from a specific network and try step 3 again. This should provide an updated list of networks that netclient have access to after the removal from a network.
5. Remove the netclient from all networks. Repeat step 3 and now it should report that no networks are available.

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
