### PR TITLE
Net 607 - set peers to nil when no peers

### DIFF
--- a/wireguard/types.go
+++ b/wireguard/types.go
@@ -28,6 +28,10 @@ var wgMutex = sync.Mutex{} // used to mutex functions of the interface
 func NewNCIface(host *config.Config, nodes config.NodeMap) *NCIface {
 	firewallMark := 0
 	peers := config.Netclient().HostPeers
+	// on freebsd, calling wgcltl.Client.ConfigureDevice() with []Peers{} causes an ioctl error --> ioctl: bad address
+	if len(peers) == 0 {
+		peers = nil
+	}
 	addrs := []ifaceAddress{}
 	for _, node := range nodes {
 		if node.Address.IP != nil {

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -26,6 +26,10 @@ func SetPeers(replace bool) error {
 	}
 	GetInterface().Config.Peers = peers
 	peers = peer.SetPeersEndpointToProxy(peers)
+	// on freebsd, calling wgcltl.Client.ConfigureDevice() with []Peers{} causes an ioctl error --> ioctl: bad address
+	if len(peers) == 0 {
+		peers = nil
+	}
 	config := wgtypes.Config{
 		ReplacePeers: replace,
 		Peers:        peers,


### PR DESCRIPTION
set NCIface.Config.Peers to nil  when no peers.

prevents ioctl: bad address error on freebsd in wgctrl.(*Client).ConfigureDevice()
