### PR TITLE
make config files readable by root only

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -213,7 +213,7 @@ func WriteNetclientConfig() error {
 		return errors.New("failed to obtain lockfile")
 	}
 	defer Unlock(lockfile)
-	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
 	if err != nil {
 		return err
 	}

--- a/config/node.go
+++ b/config/node.go
@@ -112,7 +112,7 @@ func WriteNodeConfig() error {
 		return err
 	}
 	defer Unlock(lockfile)
-	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
 	if err != nil {
 		return err
 	}

--- a/config/server.go
+++ b/config/server.go
@@ -94,7 +94,7 @@ func WriteServerConfig() error {
 		return err
 	}
 	defer Unlock(lockfile)
-	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
gui.yml remains world readable as it needs to be read by any user running netclient-gui
