### PR TITLE
NET-595

### DIFF
--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -244,6 +244,11 @@ func setupMQTT(server *config.Server) error {
 				nil,
 			)
 		}
+
+		// restart daemon for new udp hole punch if MQTT connection is lost (can happen on network change)
+		if !config.Netclient().IsStatic {
+			daemon.Restart()
+		}
 	})
 	Mqclient = mqtt.NewClient(opts)
 	var connecterr error


### PR DESCRIPTION
## Describe your changes
* Stun on network change. Restarting the netclient daemon if a network changes to perform new udp hole punch.

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps
1. Join a netclient to a network with other hosts.
2. Make sure the host do not have static endpoint enabled.
3. Take note of the current endpoint IP address.
4. Switch the netclient host internet network to a different one. (From wifi or cable to cellular data)
5. After the internet network switch, new endpoint IP address should get updated on the UI and also wireguard connections from other hosts to the network changed host in the same netmaker network should work fine.
6. Need to perform some lengthy time chaos testing on this to make sure netclient daemon restart on connection lost is not messing with any other functionalities.

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
