### PR TITLE
[NET-624] Add wireguard-tools dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.18.4
 
 WORKDIR /root/
 
-RUN apk add --no-cache --update bash libmnl gcompat openresolv iproute2 openrc \
+RUN apk add --no-cache --update bash libmnl gcompat openresolv iproute2 wireguard-tools openrc \
     && mkdir -p /run/openrc \
     && touch /run/openrc/softlevel
 RUN apk add iptables ip6tables \


### PR DESCRIPTION
## Describe your changes
Add wireguard-tools to runner docker image layer so that cleanup function in netclient.sh can do `wg show interfaces`

## Provide testing steps
Don't encounter failure logs about wg not being installed when closing netclient docker
