### PR TITLE
fix not finding netclient binary (introduced in #613)

### DIFF
--- a/scripts/netclient.sh
+++ b/scripts/netclient.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+_netclient=
+for bin in ./netclient $(which netclient 2>/dev/null ) /root/netclient ; do
+  if [ -x $bin ] ; then
+    _netclient=$bin
+    break
+  fi
+done
+if [ "${_netclient}" == "" ]; then
+    echo netclient binary not found
+    exit 1
+fi
+
 sh -c rc-status
 #Define cleanup
 cleanup() {
@@ -17,7 +29,7 @@ cleanup() {
 
 # install netclient
 echo "[netclient] starting netclient daemon"
-/root/netclient install
+$_netclient install
 wait $!
 
 # join network based on env vars
@@ -65,7 +77,7 @@ fi
 echo "[netclient] Starting netclient daemon"
 /root/netclient install
 wait $!
-netclient join $TOKEN_CMD $PORT_CMD $ENDPOINT_CMD $MTU_CMD $HOSTNAME_CMD $STATIC_CMD $IFACE_CMD $ENDPOINT6_CMD
+$_netclient join $TOKEN_CMD $PORT_CMD $ENDPOINT_CMD $MTU_CMD $HOSTNAME_CMD $STATIC_CMD $IFACE_CMD $ENDPOINT6_CMD
 if [ $? -ne 0 ]; then { echo "Failed to join, quitting." ; exit 1; } fi
 
 tail -f /var/log/netclient.log &


### PR DESCRIPTION
## Describe your changes
fix finding binary in docker startup script

## Provide testing steps
Start docker container (without this fix) so you see, that it cannot find the netlink binary so it is not working at all.
With this fix the binary ist found again.

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
