### PR TITLE
Find init in PATH when use Linux

### DIFF
--- a/daemon/common_linux.go
+++ b/daemon/common_linux.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
@@ -173,12 +175,18 @@ func GetInitType() config.InitType {
 	if runtime.GOOS != "linux" {
 		return config.UnKnown
 	}
-	out, err := ncutils.RunCmd("ls -l /sbin/init", false)
+        initPath, err := exec.LookPath("init")
 	if err != nil {
-		slog.Error("error checking /sbin/init", "error", err)
+		slog.Error("error checking init", "error", err)
 		return config.UnKnown
 	}
-	slog.Debug("checking /sbin/init", "output ", out)
+
+	out, err := ncutils.RunCmd(fmt.Sprintf("ls -l %s", initPath), true)
+	if err != nil {
+		slog.Error("error checking init", "error", err)
+		return config.UnKnown
+	}
+	slog.Debug("checking init", "output ", out)
 	if strings.Contains(out, "systemd") {
 		// ubuntu, debian, fedora, suse, etc
 		return config.Systemd


### PR DESCRIPTION
## Describe your changes

Find `init` from system `PATH` instead of hardcode the `/sbin/init` in `GetInitType` when use Linux.

Some Linux distros have no `/sbin`, such as `NixOS` , but the `init` can be found in `PATH` in most cases. 
But If there is no `init` in `PATH`, user just need change `PATH` before start netclient.

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [x] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
