### PR TITLE
NET-1106:do not set .EndpointIP if it is an IPv6 only host

### DIFF
--- a/functions/daemon.go
+++ b/functions/daemon.go
@@ -162,8 +162,12 @@ func startGoRoutines(wg *sync.WaitGroup) context.CancelFunc {
 			updateConfig = true
 		}
 		if config.Netclient().EndpointIP == nil {
-			config.Netclient().EndpointIP = config.HostPublicIP
-			updateConfig = true
+			if ipv4 := config.HostPublicIP.To4(); ipv4 != nil {
+				config.Netclient().EndpointIP = config.HostPublicIP
+				updateConfig = true
+			} else {
+				config.HostPublicIP = nil
+			}
 		}
 		if config.Netclient().NatType == "" {
 			config.Netclient().NatType = config.HostNatType


### PR DESCRIPTION
## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netclient & Netmaker are awesome.
