### PR TITLE
Add env var to set verbosity when running in docker container

### DIFF
--- a/scripts/netclient.sh
+++ b/scripts/netclient.sh
@@ -66,7 +66,7 @@ if [ "${IFACE_NAME}" != "" ];then
     IFACE_CMD="-I ${IFACE_NAME}"
 fi
 
-netclient $VERBOSITY_CMD join $TOKEN_CMD $PORT_CMD $ENDPOINT_CMD $MTU_CMD $HOSTNAME_CMD $STATIC_CMD $IFACE_CMD $ENDPOINT6_CMD
+netclient join $TOKEN_CMD $PORT_CMD $ENDPOINT_CMD $MTU_CMD $HOSTNAME_CMD $STATIC_CMD $IFACE_CMD $ENDPOINT6_CMD
 if [ $? -ne 0 ]; then { echo "Failed to join, quitting." ; exit 1; } fi
 
 tail -f /var/log/netclient.log &

--- a/scripts/netclient.sh
+++ b/scripts/netclient.sh
@@ -14,10 +14,14 @@ cleanup() {
 }
 
 
+VERBOSITY_CMD=""
+if [ "$VERBOSITY" != "" ]; then
+    VERBOSITY_CMD="-v ${VERBOSITY}"
+fi
 
 # install netclient
 echo "[netclient] starting netclient daemon"
-/root/netclient install
+/root/netclient $VERBOSITY_CMD install
 wait $!
 
 # join network based on env vars
@@ -62,7 +66,7 @@ if [ "${IFACE_NAME}" != "" ];then
     IFACE_CMD="-I ${IFACE_NAME}"
 fi
 
-netclient join $TOKEN_CMD $PORT_CMD $ENDPOINT_CMD $MTU_CMD $HOSTNAME_CMD $STATIC_CMD $IFACE_CMD $ENDPOINT6_CMD
+netclient $VERBOSITY_CMD join $TOKEN_CMD $PORT_CMD $ENDPOINT_CMD $MTU_CMD $HOSTNAME_CMD $STATIC_CMD $IFACE_CMD $ENDPOINT6_CMD
 if [ $? -ne 0 ]; then { echo "Failed to join, quitting." ; exit 1; } fi
 
 tail -f /var/log/netclient.log &


### PR DESCRIPTION
## Describe your changes
When running netcilent in a docker container, it's impossible to change the log verbosity during startup without modifying the docker entrypoint

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
