### PR TITLE
feat: add configurable interface exclusion to fix K8s endpoint detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <a href="https://netmaker.io">
   <img src="./netclient.png" width="50%"><break/>
@@ -17,7 +16,7 @@
   </a>
 </p>
 
-# Automated WireGuard® Management Client 
+# Automated WireGuard® Management Client
 
 This is the client for Netmaker networks. To learn more about Netmaker, [see here](http://github.com/gravitl/netmaker).
 
@@ -31,14 +30,27 @@ This is the client for Netmaker networks. To learn more about Netmaker, [see her
 
 ## Join a network
 
-With Token:  
+With Token:
 `netclient join -t <token>`
 
-With User (Basic Auth):  
+With User (Basic Auth):
 `netclient join -n <net name> -u <username> -s api.<netmaker domain>`
 
-With User (SSO):  
+With User (SSO):
 `netclient join -n <net name> -s api.<netmaker domain>`
+
+## Interface Exclusion
+
+Netclient excludes certain interfaces from being advertised to peers. By default, the following patterns are excluded: `docker`, `netmaker`, `flannel`, `cni`, and bridge networks.
+
+You can customize excluded interfaces using the `NETCLIENT_EXCLUDE_INTERFACES` environment variable:
+
+```bash
+NETCLIENT_EXCLUDE_INTERFACES=flannel,cni,calico,weave
+```
+
+- Comma-separated list of interface name patterns (substring match)
+- Default (if not set): `flannel,cni`
 
 ## Commands
 ```


### PR DESCRIPTION
## Describe your changes

Add configurable interface exclusion to `GetInterfaces()` to prevent Kubernetes CNI interfaces from being advertised as valid endpoints.

**Changes:**
- Exclude `flannel` and `cni` interfaces by default (following existing `docker` exclusion pattern)
- Add `NETCLIENT_EXCLUDE_INTERFACES` environment variable for customization
- Default value when unset: `flannel,cni`

**Problem solved:**
On K8s nodes, netclient detects `flannel.1` (10.42.x.x) and `cni0` interfaces and advertises them to peers. Peers then attempt connections via pod network IPs instead of actual node IPs, causing connectivity failures between nodes in different networks.

## Provide Issue ticket number if applicable/not in title

- Fixes gravitl/netmaker#2212
- Closes #1023 (Feature request: Blacklist interfaces)

## Provide link to Netmaker PR if required

N/A - netclient-only change

## Provide testing steps

1. Build netclient: `CGO_ENABLED=0 go build -o netclient .`
2. Deploy to K8s node with Flannel CNI
3. Verify `flannel.1` and `cni0` are not in advertised interfaces
4. Confirm peers receive correct node IPs (not 10.42.x.x)
5. Test custom exclusions: `NETCLIENT_EXCLUDE_INTERFACES=flannel,cni,calico`

## Checklist before requesting a review
- [x] My changes affect only 10 files or less.
- [x] I have performed a self-review of my code and tested it.
- [x] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [x] If it is a bugfix, my code is <= 200 lines.
- [x] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [x] My unit tests pass locally.
- [x] Netclient & Netmaker are awesome.
