### PR TITLE
v1.5.0 Fixes: DNS config cleanup on startup

### DIFF
--- a/dns/config/openresolv_linux.go
+++ b/dns/config/openresolv_linux.go
@@ -50,7 +50,7 @@ func (o *openresolvManager) resetConfig(iface string) error {
 	out, err := exec.Command("resolvconf", "-d", iface).CombinedOutput()
 	if err != nil {
 		out := strings.TrimSpace(string(out))
-		if strings.Contains(out, "No resolv.conf for interface") ||
+		if strings.Contains(out, "No resolv.conf") ||
 			strings.Contains(out, "Failed to resolve interface") ||
 			strings.Contains(out, "No such device") {
 			return nil

--- a/dns/config/resolvconf_linux.go
+++ b/dns/config/resolvconf_linux.go
@@ -22,7 +22,9 @@ type resolvconfManager struct {
 }
 
 func newResolvconfManager(opts ...ManagerOption) (*resolvconfManager, error) {
-	r := &resolvconfManager{}
+	r := &resolvconfManager{
+		globalResolvers: make(map[string]Config),
+	}
 	var options ManagerOptions
 	for _, opt := range opts {
 		opt(&options)

--- a/dns/config/systemd_linux.go
+++ b/dns/config/systemd_linux.go
@@ -215,7 +215,7 @@ func (s *systemdUplinkManager) Configure(iface string, config Config) error {
 
 func (s *systemdUplinkManager) resetConfig() error {
 	err := os.Remove(resolvedConfFile)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/dns/config/systemd_linux.go
+++ b/dns/config/systemd_linux.go
@@ -137,7 +137,9 @@ type systemdUplinkManager struct {
 }
 
 func newSystemdUplinkManager(opts ...ManagerOption) (*systemdUplinkManager, error) {
-	s := &systemdUplinkManager{}
+	s := &systemdUplinkManager{
+		configs: make(map[string]Config),
+	}
 	var options ManagerOptions
 	for _, opt := range opts {
 		opt(&options)


### PR DESCRIPTION
## Describe your changes

1. Don't fail if 0-netmaker.conf file doesn't exist.
2. Use a less-specific check to ensure we don't fail for different terminology (key vs interface).

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netclient & Netmaker are awesome.
