### PR TITLE
NM-266: add firewall mark flag to install cmd

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -50,12 +50,17 @@ func setInterfaceFields(cmd *cobra.Command) {
 		}
 		config.Netclient().Interface = ifaceName
 	}
+
+	if fwmark, err := cmd.Flags().GetInt(registerFlags.FwMark); err == nil && fwmark != 0 {
+		config.Netclient().FwMark = fwmark
+	}
 }
 
 func init() {
 	installCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
 	installCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
 	installCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
+	installCmd.Flags().IntP(registerFlags.FwMark, "F", 0, "sets firewall mark for wireguard traffic")
 	rootCmd.AddCommand(installCmd)
 
 	// Here you will define your flags and configuration settings.

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -35,6 +35,7 @@ var registerFlags = struct {
 	Static      string
 	Interface   string
 	Name        string
+	FwMark      string
 }{
 	Server:      "server",
 	User:        "user",
@@ -49,6 +50,7 @@ var registerFlags = struct {
 	Name:        "name",
 	Interface:   "interface",
 	Firewall:    "firewall",
+	FwMark:      "fwmark",
 }
 
 // registerCmd represents the register command

--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	NameServers    []string `json:"name_servers" yaml:"name_servers"`
 	DNSSearch      string   `json:"dns_search" yaml:"dns_search"`
 	DNSOptions     string   `json:"dns_options" yaml:"dns_options"`
+	FwMark         int      `json:"fwmark" yaml:"fwmark"`
 }
 
 func init() {

--- a/wireguard/types.go
+++ b/wireguard/types.go
@@ -30,10 +30,7 @@ var wgMutex = sync.Mutex{} // used to mutex functions of the interface
 
 // NewNCIFace - creates a new Netclient interface in memory
 func NewNCIface(host *config.Config, nodes config.NodeMap) *NCIface {
-	// FirewallMark is used for policy-based routing. Set to 0 (disabled) unless
-	// policy-based routing is specifically required. Using 0 is the standard
-	// practice when not using policy-based routing.
-	firewallMark := 0
+	firewallMark := host.FwMark
 	peers := config.Netclient().HostPeers
 	// on freebsd, calling wgcltl.Client.ConfigureDevice() with []Peers{} causes an ioctl error --> ioctl: bad address
 	if len(peers) == 0 {


### PR DESCRIPTION
## Describe your changes
Usage: netclient install --fwmark 51820 or netclient install -F 51820. 
Defaults to 0 (disabled) when not specified, preserving existing behavior.
## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netclient & Netmaker are awesome.
