### PR TITLE
NM-283: fix missing endpoint-ip6 flag name and restrict MTU flag to push cmd

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,6 +37,7 @@ func setInterfaceFields(cmd *cobra.Command) {
 			os.Exit(1)
 		}
 		config.Netclient().ListenPort = port
+		config.Netclient().IsStaticPort = true
 	}
 
 	if ifaceName, err := cmd.Flags().GetString(registerFlags.Interface); err == nil && ifaceName != "" {
@@ -55,7 +56,7 @@ func setInterfaceFields(cmd *cobra.Command) {
 func init() {
 	installCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
 	installCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
-	installCmd.Flags().IntP(registerFlags.FwMark, "F", 0, "sets firewall mark for wireguard traffic")
+	installCmd.Flags().IntP(registerFlags.FwMark, "F", 0, "sets firewall mark for netmaker traffic")
 	rootCmd.AddCommand(installCmd)
 
 	// Here you will define your flags and configuration settings.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -39,10 +39,6 @@ func setInterfaceFields(cmd *cobra.Command) {
 		config.Netclient().ListenPort = port
 	}
 
-	if isStaticPort, err := cmd.Flags().GetBool(registerFlags.StaticPort); err == nil {
-		config.Netclient().IsStaticPort = isStaticPort
-	}
-
 	if ifaceName, err := cmd.Flags().GetString(registerFlags.Interface); err == nil && ifaceName != "" {
 		if !validateIface(ifaceName) {
 			fmt.Println("invalid interface name", ifaceName)
@@ -58,7 +54,6 @@ func setInterfaceFields(cmd *cobra.Command) {
 
 func init() {
 	installCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
-	installCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
 	installCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
 	installCmd.Flags().IntP(registerFlags.FwMark, "F", 0, "sets firewall mark for wireguard traffic")
 	rootCmd.AddCommand(installCmd)

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -51,7 +51,6 @@ func init() {
 	joinCmd.Flags().StringP(registerFlags.EndpointIP, "e", "", "sets endpoint on host")
 	joinCmd.Flags().StringP(registerFlags.EndpointIP6, "E", "", "sets ipv6 endpoint on host")
 	joinCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
-	joinCmd.Flags().StringP(registerFlags.MTU, "m", "", "sets MTU on host")
 	joinCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
 	joinCmd.Flags().BoolP(registerFlags.Static, "i", false, "flag to set host as static endpoint")
 	joinCmd.Flags().StringP(registerFlags.Name, "o", "", "sets host name")

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -51,8 +51,6 @@ func init() {
 	joinCmd.Flags().StringP(registerFlags.EndpointIP, "e", "", "sets endpoint on host")
 	joinCmd.Flags().StringP(registerFlags.EndpointIP6, "E", "", "sets ipv6 endpoint on host")
 	joinCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
-	joinCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
-	joinCmd.Flags().BoolP(registerFlags.Static, "i", false, "flag to set host as static endpoint")
 	joinCmd.Flags().StringP(registerFlags.Name, "o", "", "sets host name")
 	joinCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
 	joinCmd.Flags().StringP(registerFlags.Firewall, "f", "", "selects firewall to use on host: iptables/nftables")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -24,7 +24,6 @@ func init() {
 	pushCmd.Flags().StringP(registerFlags.EndpointIP, "e", "", "sets endpoint on host")
 	pushCmd.Flags().StringP(registerFlags.EndpointIP6, "E", "", "sets ipv6 endpoint on host")
 	pushCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
-	pushCmd.Flags().IntP(registerFlags.MTU, "m", 0, "sets MTU on host")
 	pushCmd.Flags().StringP(registerFlags.Name, "o", "", "sets host name")
 	pushCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
 	pushCmd.Flags().StringP(registerFlags.Firewall, "f", "", "selects firewall to use on host: iptables/nftables")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -22,10 +22,9 @@ var pushCmd = &cobra.Command{
 
 func init() {
 	pushCmd.Flags().StringP(registerFlags.EndpointIP, "e", "", "sets endpoint on host")
+	pushCmd.Flags().StringP(registerFlags.EndpointIP6, "E", "", "sets ipv6 endpoint on host")
 	pushCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
 	pushCmd.Flags().IntP(registerFlags.MTU, "m", 0, "sets MTU on host")
-	pushCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
-	pushCmd.Flags().BoolP(registerFlags.Static, "i", false, "flag to set host as static endpoint")
 	pushCmd.Flags().StringP(registerFlags.Name, "o", "", "sets host name")
 	pushCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
 	pushCmd.Flags().StringP(registerFlags.Firewall, "f", "", "selects firewall to use on host: iptables/nftables")

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -30,7 +30,6 @@ var registerFlags = struct {
 	EndpointIP  string
 	EndpointIP6 string
 	Port        string
-	MTU         string
 	Interface   string
 	Name        string
 	FwMark      string
@@ -43,7 +42,6 @@ var registerFlags = struct {
 	EndpointIP:  "endpoint-ip",
 	EndpointIP6: "endpoint-ip6",
 	Port:        "port",
-	MTU:         "mtu",
 	Name:        "name",
 	Interface:   "interface",
 	Firewall:    "firewall",
@@ -99,9 +97,6 @@ func setHostFields(cmd *cobra.Command) {
 	if err == nil && endpointIP6 != "" {
 		config.Netclient().EndpointIPv6 = net.ParseIP(endpointIP6)
 		config.Netclient().IsStatic = true
-	}
-	if mtu, err := cmd.Flags().GetInt(registerFlags.MTU); err == nil && mtu != 0 {
-		config.Netclient().MTU = mtu
 	}
 	if hostName, err := cmd.Flags().GetString(registerFlags.Name); err == nil && hostName != "" {
 		config.Netclient().Name = hostName

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -113,16 +113,6 @@ func setHostFields(cmd *cobra.Command) {
 		}
 		config.Netclient().Interface = ifaceName
 	}
-	if config.Netclient().IsStaticPort && port == 0 {
-		fmt.Println("port from command: ", port)
-		fmt.Println("error: static port is enabled, please specify valid port with -p option")
-		os.Exit(1)
-	}
-	if config.Netclient().IsStatic && (endpointIP == "" && endpointIP6 == "") {
-		fmt.Println("endpoint from command: ", endpointIP)
-		fmt.Println("error: static endpoint is enabled, please specify valid endpoint ip with -e option")
-		os.Exit(1)
-	}
 	if firewall, err := cmd.Flags().GetString(registerFlags.Firewall); err == nil {
 		if ncutils.IsLinux() && (firewall == models.FIREWALL_IPTABLES || firewall == models.FIREWALL_NFTABLES) {
 			// check if firewall is present

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -43,6 +43,7 @@ var registerFlags = struct {
 	Network:     "net",
 	AllNetworks: "all-networks",
 	EndpointIP:  "endpoint-ip",
+	EndpointIP6: "endpoint-ip6",
 	Port:        "port",
 	MTU:         "mtu",
 	StaticPort:  "static-port",
@@ -224,7 +225,6 @@ func init() {
 	registerCmd.Flags().StringP(registerFlags.EndpointIP, "e", "", "sets endpoint on host")
 	registerCmd.Flags().StringP(registerFlags.EndpointIP6, "E", "", "sets ipv6 endpoint on host")
 	registerCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
-	registerCmd.Flags().IntP(registerFlags.MTU, "m", 0, "sets MTU on host")
 	registerCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
 	registerCmd.Flags().BoolP(registerFlags.Static, "i", false, "flag to set host as static endpoint")
 	registerCmd.Flags().StringP(registerFlags.Name, "o", "", "sets host name")

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -31,8 +31,6 @@ var registerFlags = struct {
 	EndpointIP6 string
 	Port        string
 	MTU         string
-	StaticPort  string
-	Static      string
 	Interface   string
 	Name        string
 	FwMark      string
@@ -46,8 +44,6 @@ var registerFlags = struct {
 	EndpointIP6: "endpoint-ip6",
 	Port:        "port",
 	MTU:         "mtu",
-	StaticPort:  "static-port",
-	Static:      "static-endpoint",
 	Name:        "name",
 	Interface:   "interface",
 	Firewall:    "firewall",
@@ -92,17 +88,17 @@ func setHostFields(cmd *cobra.Command) {
 			os.Exit(1)
 		}
 		config.Netclient().ListenPort = port
-	}
-	if isStatic, err := cmd.Flags().GetBool(registerFlags.Static); err == nil {
-		config.Netclient().IsStatic = isStatic
+		config.Netclient().IsStaticPort = true
 	}
 	endpointIP, err := cmd.Flags().GetString(registerFlags.EndpointIP)
 	if err == nil && endpointIP != "" {
 		config.Netclient().EndpointIP = net.ParseIP(endpointIP)
+		config.Netclient().IsStatic = true
 	}
 	endpointIP6, err := cmd.Flags().GetString(registerFlags.EndpointIP6)
 	if err == nil && endpointIP6 != "" {
 		config.Netclient().EndpointIPv6 = net.ParseIP(endpointIP6)
+		config.Netclient().IsStatic = true
 	}
 	if mtu, err := cmd.Flags().GetInt(registerFlags.MTU); err == nil && mtu != 0 {
 		config.Netclient().MTU = mtu
@@ -116,9 +112,6 @@ func setHostFields(cmd *cobra.Command) {
 			os.Exit(1)
 		}
 		config.Netclient().Interface = ifaceName
-	}
-	if isStaticPort, err := cmd.Flags().GetBool(registerFlags.StaticPort); err == nil {
-		config.Netclient().IsStaticPort = isStaticPort
 	}
 	if config.Netclient().IsStaticPort && port == 0 {
 		fmt.Println("port from command: ", port)
@@ -223,8 +216,6 @@ func init() {
 	registerCmd.Flags().StringP(registerFlags.EndpointIP, "e", "", "sets endpoint on host")
 	registerCmd.Flags().StringP(registerFlags.EndpointIP6, "E", "", "sets ipv6 endpoint on host")
 	registerCmd.Flags().IntP(registerFlags.Port, "p", 0, "sets wg listen port")
-	registerCmd.Flags().BoolP(registerFlags.StaticPort, "j", false, "flag to set host as static port")
-	registerCmd.Flags().BoolP(registerFlags.Static, "i", false, "flag to set host as static endpoint")
 	registerCmd.Flags().StringP(registerFlags.Name, "o", "", "sets host name")
 	registerCmd.Flags().StringP(registerFlags.Interface, "I", "", "sets netmaker interface to use on host")
 	registerCmd.Flags().StringP(registerFlags.Firewall, "f", "", "selects firewall to use on host")

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -99,12 +99,10 @@ func setHostFields(cmd *cobra.Command) {
 	endpointIP, err := cmd.Flags().GetString(registerFlags.EndpointIP)
 	if err == nil && endpointIP != "" {
 		config.Netclient().EndpointIP = net.ParseIP(endpointIP)
-		config.Netclient().IsStatic = true
 	}
 	endpointIP6, err := cmd.Flags().GetString(registerFlags.EndpointIP6)
 	if err == nil && endpointIP6 != "" {
 		config.Netclient().EndpointIPv6 = net.ParseIP(endpointIP6)
-		config.Netclient().IsStatic = true
 	}
 	if mtu, err := cmd.Flags().GetInt(registerFlags.MTU); err == nil && mtu != 0 {
 		config.Netclient().MTU = mtu

--- a/scripts/netclient.sh
+++ b/scripts/netclient.sh
@@ -64,4 +64,4 @@ fi
 
 # Run daemon directly as the foreground process
 echo "[netclient] starting netclient daemon"
-exec /root/netclient $VERBOSITY_CMD daemon
+exec /root/netclient daemon $VERBOSITY_CMD

--- a/scripts/netclient.sh
+++ b/scripts/netclient.sh
@@ -48,16 +48,6 @@ if [ "${HOST_NAME}" != "" ]; then
     HOSTNAME_CMD="-o ${HOST_NAME}"
 fi
 
-STATIC_CMD=""
-if [ "${IS_STATIC}" != "" ]; then
-    STATIC_CMD="-i ${IS_STATIC}"
-fi
-
-STATIC_PORT_CMD=""
-if [ "${IS_STATIC_PORT}" != "" ]; then
-    STATIC_PORT_CMD="-j ${IS_STATIC_PORT}"
-fi
-
 IFACE_CMD=""
 if [ "${IFACE_NAME}" != "" ]; then
     IFACE_CMD="-I ${IFACE_NAME}"

--- a/scripts/netclient.sh
+++ b/scripts/netclient.sh
@@ -38,11 +38,6 @@ if [ "${ENDPOINT6}" != "" ]; then
     ENDPOINT6_CMD="-E ${ENDPOINT6}"
 fi
 
-MTU_CMD=""
-if [ "${MTU}" != "" ]; then
-    MTU_CMD="-m ${MTU}"
-fi
-
 HOSTNAME_CMD=""
 if [ "${HOST_NAME}" != "" ]; then
     HOSTNAME_CMD="-o ${HOST_NAME}"


### PR DESCRIPTION

The EndpointIP6 field was not initialized in registerFlags, causing the --endpoint-ip6 / -E flag to render as an unnamed flag. Also remove the MTU flag from join and register commands since MTU should only be changed via push after the host is already enrolled.

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netclient & Netmaker are awesome.
