### PR TITLE
fix: use sync.Map.Clear() in endpoint cache reset (avoid race)

### DIFF
--- a/functions/mqhandlers.go
+++ b/functions/mqhandlers.go
@@ -301,8 +301,8 @@ func HostPeerUpdate(client mqtt.Client, msg mqtt.Message) {
 		}
 	}
 	if !peerUpdate.ServerConfig.EndpointDetection {
-		cache.EndpointCache = sync.Map{}
-		cache.SkipEndpointCache = sync.Map{}
+		cache.EndpointCache.Clear()
+		cache.SkipEndpointCache.Clear()
 	}
 	config.UpdateHostPeers(peerUpdate.Peers)
 	_ = wireguard.SetPeers(peerUpdate.ReplacePeers)
@@ -882,8 +882,8 @@ func mqFallbackPull(pullResponse models.HostPull, resetInterface, replacePeers b
 		}
 	}
 	if !pullResponse.ServerConfig.EndpointDetection {
-		cache.EndpointCache = sync.Map{}
-		cache.SkipEndpointCache = sync.Map{}
+		cache.EndpointCache.Clear()
+		cache.SkipEndpointCache.Clear()
 	}
 	config.UpdateHostPeers(pullResponse.Peers)
 	_ = wireguard.SetPeers(pullResponse.ReplacePeers)


### PR DESCRIPTION
## Problem

Two locations in `functions/mqhandlers.go` reset the endpoint discovery caches by reassigning a fresh `sync.Map{}` value to the package-level `cache.EndpointCache` and `cache.SkipEndpointCache`:

```go
if !peerUpdate.ServerConfig.EndpointDetection {
    cache.EndpointCache = sync.Map{}
    cache.SkipEndpointCache = sync.Map{}
}
```

This violates the documented `sync.Map` contract — *"A Map must not be copied after first use"* ([pkg.go.dev/sync#Map](https://pkg.go.dev/sync#Map)) — and races against `Load()` calls in `wireguard.checkForBetterEndpoint`, which is invoked concurrently from `wireguard.SetPeers` later in the same handler. On Go 1.23+ where `sync.Map` is implemented via `internal/sync.HashTrieMap`, the race can produce a nil-pointer deref inside the trie's lazily initialized root.

## Observed in production

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4a1811]

internal/sync.(*HashTrieMap[...]).Load(0x15b8340, {0x113d5c0, 0xc002d53900})
        internal/sync/hashtriemap.go:73 +0x71
sync.(*Map).Load(...)
        sync/hashtriemap.go:50
github.com/gravitl/netclient/wireguard.checkForBetterEndpoint(0xc002d53970)
        wireguard/wireguard.go:112 +0x6e
github.com/gravitl/netclient/wireguard.SetPeers(0x0)
        wireguard/wireguard.go:63 +0x1e5
github.com/gravitl/netclient/functions.HostPeerUpdate({...}, {...})
        functions/mqhandlers.go:303 +0x100b
github.com/eclipse/paho.mqtt.golang.(*router).matchAndDispatch.func2.1()
        router.go:170 +0x3d
```

(netclient v1.4.0, Go 1.25.3.)

## Fix

Replace the value-assignment with `sync.Map.Clear()` (Go 1.23+, available since `go.mod` specifies `go 1.25.3`). `Clear()` empties the map atomically and is safe under concurrent reads.

```diff
 if !peerUpdate.ServerConfig.EndpointDetection {
-    cache.EndpointCache = sync.Map{}
-    cache.SkipEndpointCache = sync.Map{}
+    cache.EndpointCache.Clear()
+    cache.SkipEndpointCache.Clear()
 }
```

Same change applied at both call sites (`HostPeerUpdate` and `mqFallbackPull`).