### PR TITLE
fix(go): restore nftables egress MASQUERADE on default iface

### DIFF
--- a/firewall/nftables_linux.go
+++ b/firewall/nftables_linux.go
@@ -688,11 +688,6 @@ func (n *nftablesManager) InsertEgressRoutingRules(server string, egressInfo mod
 			logger.Log(0, "failed to get interface name: ", egressRangeIface, err.Error())
 		} else {
 			logger.Log(0, fmt.Sprintf("Egress range %s uses interface: %s", egressGwRange.Network, egressRangeIface))
-			defaultIface := config.Netclient().DefaultInterface
-			if egressRangeIface == defaultIface || egressRangeIface == "eth0" {
-				logger.Log(0, fmt.Sprintf("skipping destination-specific egress SNAT rule for %s via default interface %s", egressGwRange.Network, egressRangeIface))
-				continue
-			}
 			n.insertEgressForwardAclJumpNft(egressRangeIface, fwdJumpDedupe, &egressGwRoutes)
 			ruleSpec := []string{"-s", source, "-o", egressRangeIface, "-j", "MASQUERADE"}
 			// to avoid duplicate iface route rule,delete if exists
@@ -805,7 +800,11 @@ func (n *nftablesManager) InsertEgressRoutingRules(server string, egressInfo mod
 				})
 			}
 			// Add additional egress NAT rule for LAN CIDR traffic exiting via VPN interface.
-			if isAddrIpv4(egressGwRange.Network) {
+			// Skip when egress is via the default/WAN interface (same as iptables).
+			defaultIface := config.Netclient().DefaultInterface
+			if egressRangeIface == defaultIface || egressRangeIface == "eth0" {
+				logger.Log(0, fmt.Sprintf("skipping destination-specific egress SNAT rule for %s via default interface %s", egressGwRange.Network, egressRangeIface))
+			} else if isAddrIpv4(egressGwRange.Network) {
 				lanCIDR := config.ToIPNet(egressGwRange.Network)
 				additionalRuleSpec := []string{
 					"-s", egressGwRange.Network,


### PR DESCRIPTION
Skip only the LAN-to-VPN SNAT when egress uses the default/WAN interface; keep primary egress masquerade (NM-291 regression).

## Describe your changes

## Provide Issue ticket number if applicable/not in title

## Provide link to Netmaker PR if required

## Provide testing steps

## Checklist before requesting a review
- [ ] My changes affect only 10 files or less.
- [ ] I have performed a self-review of my code and tested it.
- [ ] If it is a new feature, I have added thorough tests, my code is <= 1450 lines.
- [ ] If it is a bugfix, my code is <= 200 lines.
- [ ] My functions are <= 80 lines.
- [ ] I have had my code reviewed by a peer.
- [ ] My unit tests pass locally.
- [ ] Netclient & Netmaker are awesome.
